### PR TITLE
Change Discord Link to PGM Discord

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,7 +73,7 @@ module.exports = {
           items: [
             {
               label: "Discord",
-              href: "https://discord.gg/CvJGbrV",
+              href: "https://discord.gg/pEEcwTk",
             },
             {
               label: "Twitter",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,7 +35,7 @@ const features = [
     description: (
       <>
         Be part of a community of over 20 contributors and help keep the project
-        alive! Our <a href="https://discord.gg/CvJGbrV">Discord server</a> is
+        alive! Our <a href="https://discord.gg/pEEcwTk">Discord server</a> is
         the best place to discuss bug fixes and implementations in real time.
       </>
     ),


### PR DESCRIPTION
Makes it consistent with the discord change. Possibly might want to remove the twitter section if that is used as OCC twitter.