### PR TITLE
Fix docs editUrl config option

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,7 +108,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/PGMDev/Website",
+          editUrl: "https://github.com/PGMDev/Website/edit/master/",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
The "Edit this page" link currently does not work.

![image](https://user-images.githubusercontent.com/8608892/88491110-7d286780-cf98-11ea-8a0f-0c9f8ca3b728.png)

Looked at a few other repos that use the package and this seems correct, not tested it tho. I assume it appends the `/docs/` bit but maybe not, info on config option found [https://docusaurus.io/docs/en/site-config#editurl-string](here).
