### PR TITLE
added documentation for overtime and max-overtime attributes

### DIFF
--- a/docs/modules/objectives/scoring.mdx
+++ b/docs/modules/objectives/scoring.mdx
@@ -401,7 +401,7 @@ Result can be the name of a team, or one of the special values; "tie" for no win
 
 #### Overtime
 
-Overtime can be used in order to force a single winner in a match.  By using the optional `overtime="..."` attribute in the time element, you can specify a <a href="/docs/reference/misc/time-periods">time period</a>. If the score is tied once regulation time ends, the match will extend into overtime. The time will begin to tick down as soon as the tie is broken. It will reset back to the specified time if a tie is reached again before the time expires.
+Overtime can be used in order to force a single winner in a match.  By using the optional `overtime="..."` attribute in the time element, you can specify a <a href="/docs/reference/misc/time-periods">time period</a>. If the score is tied once regulation time ends, the match will extend into overtime. The time will begin to tick down as soon as the tie is broken. It will reset back to the specified time if a tie is reached again or a change in the lead occurs before the time expires.
 
 To limit how long overtime lasts, you can include the `max-overtime="..."` attribute as well.  It, too, accepts a <a href="/docs/reference/misc/time-periods">time period</a> as a value. This will count down in the background and force the overtime to count down once surpassing the `overtime="..."` attribute's value.
 

--- a/docs/modules/objectives/scoring.mdx
+++ b/docs/modules/objectives/scoring.mdx
@@ -413,7 +413,7 @@ Example
 ```xml
 <!-- Match will last 12 minutes.
      If score is tied when time reaches zero, a one-minute overtime starts. If the tie is broken 
-     and no team makes a comeback, the overtime will tick down. 
+     and no team makes a comeback within one minute, the leading team will win. 
      The overtime will last a maximum of 15 minutes -->
 <time overtime="1m" max-overtime="15m">12m</time>
 ```

--- a/docs/modules/objectives/scoring.mdx
+++ b/docs/modules/objectives/scoring.mdx
@@ -377,6 +377,43 @@ Result can be the name of a team, or one of the special values; "tie" for no win
         </td>
         <td>true</td>
       </tr>
+      <tr>
+        <td>
+          <label>overtime</label>
+        </td>
+        <td>Specify the length of the overtime once the tie is broken.</td>
+        <td>
+          <a href="/docs/reference/misc/time-periods">Time Period</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>max-overtime</label>
+        </td>
+        <td>Specify a maximum duration that the overtime should last.</td>
+        <td>
+          <a href="/docs/reference/misc/time-periods">Time Period</a>
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>
+
+#### Overtime
+
+Overtime can be used in order to force a single winner in a match.  By using the optional `overtime="..."` attribute in the time element, you can specify a <a href="/docs/reference/misc/time-periods">time period</a>. If the score is tied once regulation time ends, the match will extend into overtime. The time will begin to tick down as soon as the tie is broken. It will reset back to the specified time if a tie is reached again before the time expires.
+
+To limit how long overtime lasts, you can include the `max-overtime="..."` attribute as well.  It, too, accepts a <a href="/docs/reference/misc/time-periods">time period</a> as a value. This will count down in the background and force the overtime to count down once surpassing the `overtime="..."` attribute's value.
+
+`Tip:` Set the `overtime="..."` attribute to `1s` for sudden death overtime.
+
+
+Example
+
+```xml
+<!-- Match will last 12 minutes.
+     If score is tied when time reaches zero, a one-minute overtime starts. If the tie is broken 
+     and no team makes a comeback, the overtime will tick down. 
+     The overtime will last a maximum of 15 minutes -->
+<time overtime="1m" max-overtime="15m">12m</time>
+```


### PR DESCRIPTION
I added documentation to the time element for the overtime attributes.  I think the descriptions are correct, although I interpreted it the best I could.