### PR TITLE
Update Examples and Make Minor Changes

### DIFF
--- a/docs/guides/xml-pointers/filter-apply-order.mdx
+++ b/docs/guides/xml-pointers/filter-apply-order.mdx
@@ -9,9 +9,9 @@ Here's an example.
 Let's start out with a basic filter that **denies** everything **except** TNT.
 
 ```xml
-<filter name="only-tnt">
+<all id="only-tnt">
     <block>tnt</block>
-</filter>
+</all>
 ```
 
 Now let's apply this filter to `Region A`, and also apply a filter to `Region B` that denies all blocks.

--- a/docs/modules/gear/classes.mdx
+++ b/docs/modules/gear/classes.mdx
@@ -58,8 +58,8 @@ Classes allow the player to pick a specific class at the beginning of the game w
           <label>name</label>
         </td>
         <td>
-          <span className="badge badge--danger">Required</span> The classes
-          name, must be a unique.
+          <span className="badge badge--danger">Required</span> The class's
+          name, must be unique.
         </td>
         <td>
           <span className="badge badge--primary">String</span>

--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -62,16 +62,6 @@ The maps version should follow the versioning schema `major.minor.patch`.
       </tr>
       <tr>
         <td>
-          <label>game</label>
-        </td>
-        <td>A custom title for this match's gamemode.</td>
-        <td>
-          <span className="badge badge--primary">String</span>
-        </td>
-        <td />
-      </tr>
-      <tr>
-        <td>
           <label>internal</label>
         </td>
         <td>Prevent compass teleports above Y 255</td>
@@ -206,6 +196,16 @@ The maps version should follow the versioning schema `major.minor.patch`.
         <td>
           <label>standard</label>
         </td>
+      </tr>
+      <tr>
+        <td>
+          <label>{`<game>`}</label>
+        </td>
+        <td>A custom title for this match's gamemode.</td>
+        <td>
+          <span className="badge badge--primary">String</span>
+        </td>
+        <td />
       </tr>
       <tr>
         <td>

--- a/docs/modules/information/broadcasts.mdx
+++ b/docs/modules/information/broadcasts.mdx
@@ -9,7 +9,7 @@ The text in broadcasts can be formatted by using [formatting codes](/docs/refere
 
 <span className="badge badge--warning">Note!</span> This module should **only** be
 used to to show important information that is **specific** and **unique** to the
-map. It should not be used for generic server related messages.
+map. It should not be used to for generic server related messages.
 
 <div className="table-container">
   <table>

--- a/docs/modules/information/broadcasts.mdx
+++ b/docs/modules/information/broadcasts.mdx
@@ -9,7 +9,7 @@ The text in broadcasts can be formatted by using [formatting codes](/docs/refere
 
 <span className="badge badge--warning">Note!</span> This module should **only** be
 used to to show important information that is **specific** and **unique** to the
-map. It should not be used to for generic server related messages.
+map. It should not be used for generic server related messages.
 
 <div className="table-container">
   <table>

--- a/docs/modules/information/broadcasts.mdx
+++ b/docs/modules/information/broadcasts.mdx
@@ -9,7 +9,7 @@ The text in broadcasts can be formatted by using [formatting codes](/docs/refere
 
 <span className="badge badge--warning">Note!</span> This module should **only** be
 used to to show important information that is **specific** and **unique** to the
-map. It should not be used to for generic OCN related messages.
+map. It should not be used to for generic server related messages.
 
 <div className="table-container">
   <table>

--- a/docs/modules/mechanics/portals.mdx
+++ b/docs/modules/mechanics/portals.mdx
@@ -382,5 +382,8 @@ _Examples_
     <portal region="portal-entrance">
         <destination><region id="portal-exit"/></destination>
     </portal>
+
+    <!-- Teleports players on the Red Team from score-box to red-spawn, facing west
+    <portal filter="only-red" yaw="@90" region="score-box" destination="red-spawn"/>
 </portals>
 ```

--- a/docs/modules/mechanics/portals.mdx
+++ b/docs/modules/mechanics/portals.mdx
@@ -383,7 +383,7 @@ _Examples_
         <destination><region id="portal-exit"/></destination>
     </portal>
 
-    <!-- Teleports players on the Red Team from score-box to red-spawn, facing west
+    <!-- Teleports players on the Red Team from score-box to red-spawn, facing west -->
     <portal filter="only-red" yaw="@90" region="score-box" destination="red-spawn"/>
 </portals>
 ```

--- a/docs/modules/mechanics/regions.mdx
+++ b/docs/modules/mechanics/regions.mdx
@@ -149,7 +149,7 @@ The area a region applies to is specified with one or more of the following elem
         <td>
           <label>{`<nowhere/>`}</label>
           <br />A reference-able zero size/position region, contains nothing. Can
-          be referenced with the ID: <label>nowhere</label>
+          be referenced with the region ID: <label>nowhere</label>
         </td>
         <td></td>
       </tr>
@@ -157,7 +157,7 @@ The area a region applies to is specified with one or more of the following elem
         <td>
           <label>{`<everywhere/>`}</label>
           <br />A reference-able infinite size region, contains everything. Can be
-          referenced with the ID: <label>everywhere</label>
+          referenced with the region ID: <label>everywhere</label>
         </td>
         <td></td>
       </tr>

--- a/docs/modules/mechanics/spawns.mdx
+++ b/docs/modules/mechanics/spawns.mdx
@@ -82,6 +82,10 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
           <label>team</label>
         </td>
         <td>The team this spawn applies to.</td>
+        <br />
+        <i>
+          Not needed for team-less gamemodes.
+        </i>
         <td>
           <a href="/docs/modules/format/teams">Team ID</a>
         </td>

--- a/docs/modules/objectives/blitz.mdx
+++ b/docs/modules/objectives/blitz.mdx
@@ -10,7 +10,7 @@ If the match timer ends before a team is eliminated the team with the most playe
 
 The blitz module is used with the [Ghost Squadron](/docs/modules/objectives/other#gs) gamemode, and is also often combined with the [rage](/docs/modules/objectives/other#rage) module.
 
-Blitz maps should include the [global blitz XML](https://raw.githubusercontent.com/OvercastNetwork/maps.oc.tc/master/Include/blitz-global.xml) file.
+Blitz maps should include `<respawn auto="true"/>` to prevent players from "hiding" and prolonging matches.
 
 <div className="table-container">
   <table>
@@ -71,7 +71,7 @@ Example:
 <!-- Time till the match ends in minutes -->
 <time>10m</time>
 
-<include src="blitz-global.xml"/>
+<respawn auto="true"/>
 ```
 
 ```xml

--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -6,7 +6,7 @@ title: Control Points
 Control point give a certain amount of point to the team currently holding it. Once a team has captured all points, or reached a certain score (using the [score module](/docs/modules/objectives/scoring)) the match ends. Control points can be mixed with and used in addition to other gamemodes. Other uses of control points include unlocking an area of the map using objective filters, etc.
 
 ```xml
-<control-points capture-players="lead" incremental="true" show-progress="true">
+<control-points capture-rule="lead" incremental="true" show-progress="true">
     <control-point name="Center" capture-time="20s">
         <capture><cylinder base="0.5,23,7.5" radius="7" height="5"/></capture>
         <progress><cylinder base="0.5,22,7.5" radius="7" height="4"/></progress>

--- a/docs/modules/objectives/other.mdx
+++ b/docs/modules/objectives/other.mdx
@@ -5,14 +5,14 @@ title: Other Gamemodes
 
 ### Ghost Squadron
 
-The ghostsquadron gamemode can be quicky adapted in conjunction with the Bliz gamemode.
+The ghostsquadron gamemode can be quicky adapted in conjunction with the Blitz gamemode.
 The default ghostsquadron classes and setup can be found [here](https://raw.githubusercontent.com/OvercastNetwork/maps.oc.tc/master/Blitz/GS/gs.xml).
 Ghost squadron maps are set a custom gamemode title using the `<game>` tag.
 
 ```xml
 <game>Ghost Squadron</game>
 
-<!-- insert ghostsquadron setup --> 
+<!-- Insert ghostsquadron setup -->
 
 <time>4m</time>
 <blitz>

--- a/docs/modules/objectives/other.mdx
+++ b/docs/modules/objectives/other.mdx
@@ -5,18 +5,16 @@ title: Other Gamemodes
 
 ### Ghost Squadron
 
-Enables the ghostsquadron gamemode and all its features.
-The default ghostsquadron classes can be found [here](https://raw.githubusercontent.com/OvercastNetwork/maps.oc.tc/master/Blitz/GS/gs.xml).
-Ghost squadron maps set a custom gamemode title in the `gs.xml` with the `<map game="Ghost Squadron">` attribute.
-When not using the default GS XML include a custom title should be set.
-
-`NOTE:` This module must be used in conjunction with another gamemode.
+The ghostsquadron gamemode can be quicky adapted in conjunction with the Bliz gamemode.
+The default ghostsquadron classes and setup can be found [here](https://raw.githubusercontent.com/OvercastNetwork/maps.oc.tc/master/Blitz/GS/gs.xml).
+Ghost squadron maps are set a custom gamemode title using the `<game>` tag.
 
 ```xml
-<ghostsquadron />
-<include src="gs.xml" />
+<game>Ghost Squadron</game>
 
-<time>6m</time>
+<!-- insert ghostsquadron setup --> 
+
+<time>4m</time>
 <blitz>
     <broadcastLives>false</broadcastLives>
 </blitz>

--- a/docs/modules/objectives/other.mdx
+++ b/docs/modules/objectives/other.mdx
@@ -7,7 +7,7 @@ title: Other Gamemodes
 
 The ghostsquadron gamemode can be quicky adapted in conjunction with the Blitz gamemode.
 The default ghostsquadron classes and setup can be found [here](https://raw.githubusercontent.com/OvercastNetwork/maps.oc.tc/master/Blitz/GS/gs.xml).
-Ghost squadron maps are set a custom gamemode title using the `<game>` tag.
+Ghost squadron maps are set with a custom gamemode title using the `<game>` tag.
 
 ```xml
 <game>Ghost Squadron</game>

--- a/docs/modules/objectives/other.mdx
+++ b/docs/modules/objectives/other.mdx
@@ -3,40 +3,6 @@ id: other
 title: Other Gamemodes
 ---
 
-### Ghost Squadron
-
-The ghostsquadron gamemode can be quicky adapted in conjunction with the Blitz gamemode.
-The default ghostsquadron classes and setup can be found [here](https://raw.githubusercontent.com/OvercastNetwork/maps.oc.tc/master/Blitz/GS/gs.xml).
-Ghost squadron maps are set with a custom gamemode title using the `<game>` tag.
-
-```xml
-<game>Ghost Squadron</game>
-
-<!-- Insert ghostsquadron setup -->
-
-<time>4m</time>
-<blitz>
-    <broadcastLives>false</broadcastLives>
-</blitz>
-```
-
-### Rage
-
-Enable the one hit kill, rage style gamemode.
-
-One hit kills will only be applied to items that have a sharpness enchantment greater than level 1. One shot arrow kills will only be applied to bows that have a power enchantment greater than level 1.
-
-`NOTE:` This module must be used in conjunction with another gamemode.
-
-```xml
-<rage/>
-
-<time>8m</time>
-<score>
-    <limit>15</limit>
-</score>
-```
-
 ### Team Death-match
 
 This gamemode uses the [scoring](/docs/modules/objectives/scoring) module to run the game for a specified amount of time, after which the team with the highest score wins. Teams increase their score by killing players from the other team or capturing points from a [score box](/docs/modules/objectives/scoring#score_box).
@@ -67,5 +33,22 @@ Depending on the modules used, players can increase their score by killing other
 <score>
     <kills>1</kills>
     <deaths>1</deaths>
+</score>
+```
+
+### Rage
+
+Enable the one hit kill, rage style gamemode.
+
+One hit kills will only be applied to items that have a sharpness enchantment greater than level 1. One shot arrow kills will only be applied to bows that have a power enchantment greater than level 1.
+
+`NOTE:` This module must be used in conjunction with another gamemode.
+
+```xml
+<rage/>
+
+<time>8m</time>
+<score>
+    <limit>15</limit>
 </score>
 ```

--- a/docs/modules/objectives/scoring.mdx
+++ b/docs/modules/objectives/scoring.mdx
@@ -302,7 +302,7 @@ Example
 </score>
 
 <score>
-    <box value="8" filter="cyan" region="cyan-scorebox"/>
+    <box points="8" filter="cyan" region="cyan-scorebox"/>
 </score>
 ```
 
@@ -412,8 +412,8 @@ Example
 
 ```xml
 <!-- Match will last 12 minutes.
-     If score is tied when time reaches zero, a one-minute overtime starts. If the tie is broken 
-     and no team makes a comeback within one minute, the leading team will win. 
+     If score is tied when time reaches zero, a one-minute overtime starts. If the tie is broken
+     and no team makes a comeback within one minute, the leading team will win.
      The overtime will last a maximum of 15 minutes -->
 <time overtime="1m" max-overtime="15m">12m</time>
 ```


### PR DESCRIPTION
This pull request updates some outdated examples and makes small changes to the documentation so it is more clear.

 - Added new portal example using two referenced regions in a self contained tag
 - Move the `game` attribute to `<map>` as a `<game>` tag
 - Replace `<include>` reference in Blitz with `<respawn auto="true"/>`
 - Remove references to `<ghostsquadron/>` and explain how it is adapted from the Blitz gamemode.
 - Minor spelling changes and fixes for clarification.

I was also thinking of readapting the sample ghostsquadron XML to a working usable template that can be mentioned in the examples section.