### PR TITLE
Add Potions Reference

### DIFF
--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -159,7 +159,10 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         <td>
           <label>damage</label>
         </td>
-        <td>The item's damage, used for items such as birch logs.</td>
+        <td>
+          The item's damage, used for items such as birch logs, red wool, potion
+          types, etc.
+        </td>
         <td>
           <span className="badge badge--primary">Number</span>
         </td>
@@ -549,41 +552,9 @@ However, if any custom effects are present, they will completely replace the def
 By default when a player drinks a potion bottle the empty bottle is automatically removed from the players inventory.
 This behavior can be disabled with the `<keep-potion-bottles/>` tag.
 
-See [Potion Effects](/docs/modules/gear/potions) for details on the effects element.
+See [Potion Effects](/docs/modules/gear/potions) for details on the `<effect>` element.
 
-Also see [Minecraft wiki - Potion](http://www.minecraftwiki.net/wiki/Potions)
-and [Minecraft wiki - Status Effect](http://minecraft.gamepedia.com/Status_effect)
-
-##### Potion Item Attributes
-
-<div className="table-container">
-  <table>
-    <thead>
-      <tr>
-        <th>Attribute</th>
-        <th>Description</th>
-        <th>Value</th>
-        <th>Default</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <label>potion</label>
-        </td>
-        <td>Potion type</td>
-        <td>
-          <a href="http://minecraft.gamepedia.com/Potion#Data_values">
-            Potion ID
-          </a>
-        </td>
-        <td>
-          <label>minecraft:empty</label>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+Also see the [Potions & Effects](/docs/modules/gear/potions) reference page.
 
 ##### Potion Item Sub-elements
 
@@ -611,9 +582,12 @@ and [Minecraft wiki - Status Effect](http://minecraft.gamepedia.com/Status_effec
 </div>
 
 ```xml
-<item slot="0" material="lingering potion" potion="strong_harming"/>
-<item slot="1" material="potion" potion="fire_resistance">
+<item slot="1" material="potion" damage="3">
     <effect duration="15m">fire_resistance</effect>
+</item>
+<!-- A Jump Boost Splash Potion -->
+<item slot="0" material="potion" damage="16395">
+    <effect duration="3m" amplifier="2">jump_boost</effect>
 </item>
 ```
 

--- a/docs/modules/gear/potions.mdx
+++ b/docs/modules/gear/potions.mdx
@@ -80,7 +80,6 @@ Effect IDs should be specified without their `minecraft:` prefix.
 _Example_
 
 ```xml
-<effect duration="2" amplifier="10">resistance</effect>
 <effect duration="900" amplifier="1">jump_boost</effect>
 <!-- Commonly used to prevent unintended damage when spawning -->
 <effect duration="2" amplifier="10">damage_resistance</effect>

--- a/docs/modules/gear/potions.mdx
+++ b/docs/modules/gear/potions.mdx
@@ -7,8 +7,8 @@ The potion `<effect>` element can be used in a kit to apply potion effects direc
 or used to give a custom effect to a [potion bottle item](/docs/modules/gear/items#potions).
 
 Duration specifies how long the potion will last, and amplifier determines what level / how strong the potion is.
-The effect type is specified by its [Minecraft ID](http://minecraft.gamepedia.com/Data_values#Status_effects).
-Effect ID's should be specified without their `minecraft:` prefix.
+The effect type is specified by its [Minecraft ID](/docs/reference/items/potions#potion-names--colors).
+Effect IDs should be specified without their `minecraft:` prefix.
 
 ##### Effect Element
 
@@ -28,7 +28,7 @@ Effect ID's should be specified without their `minecraft:` prefix.
         </td>
         <td>A potion effect</td>
         <td>
-          <a href="http://minecraft.gamepedia.com/Data_values#Status_effects">
+          <a href="/docs/reference/items/potions#potion-names--colors">
             Status Effect ID
           </a>
         </td>
@@ -80,6 +80,9 @@ Effect ID's should be specified without their `minecraft:` prefix.
 _Example_
 
 ```xml
-<effect duration="10" amplifier="4">resistance</effect>
+<effect duration="2" amplifier="10">resistance</effect>
 <effect duration="900" amplifier="1">jump_boost</effect>
+<!-- Commonly used to prevent unintended damage when spawning -->
+<effect duration="2" amplifier="10">damage_resistance</effect>
+
 ```

--- a/docs/reference/items/potions.mdx
+++ b/docs/reference/items/potions.mdx
@@ -195,4 +195,10 @@ Splash potions are determined by adding the damage value `16384` to the chosen p
     <!-- Overwrites original three minute Speed I effect -->
     <effect duration="1m" amplifier="2">speed</effect>
 </item>
+
+<!-- 16384 + 5 = 16389 -->
+<!-- Splash potion + Speed color = Splash Potion of Instant Health I -->
+<item amount="1" material="potion" damage="16389">
+    <effect amplifier="1">instant_health</effect>
+</item>
 ```

--- a/docs/reference/items/potions.mdx
+++ b/docs/reference/items/potions.mdx
@@ -1,0 +1,198 @@
+---
+id: potions
+title: Potions & Effects
+---
+
+### Potion Names & Colors
+
+Damage values for potion names/colors, and their effect names for `<effect>`.
+These are intended for use to set the potion color, potion type, and default name.
+Use the `<effect>` element to set duration, amplifier, custom name, and actual potion effect.
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Damage Value</th>
+        <th>Potion Name</th>
+        <th>Status Effect</th>
+        <th>Color</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>0</label>
+        </td>
+        <td>Water Bottle</td>
+        <td>
+          <label>N/A</label>
+        </td>
+        <td>Blue</td>
+      </tr>
+      <tr>
+        <td>
+          <label>1</label>
+        </td>
+        <td>Potion of Regeneration</td>
+        <td>
+          <label>regeneration</label>
+        </td>
+        <td>Pink</td>
+      </tr>
+      <tr>
+        <td>
+          <label>2</label>
+        </td>
+        <td>Potion of Swiftness</td>
+        <td>
+          <label>speed</label>
+        </td>
+        <td>Sky Blue</td>
+      </tr>
+      <tr>
+        <td>
+          <label>3</label>
+        </td>
+        <td>Potion of Fire Resistance</td>
+        <td>
+          <label>fire_resistance</label>
+        </td>
+        <td>Orange</td>
+      </tr>
+      <tr>
+        <td>
+          <label>4</label>
+        </td>
+        <td>Potion of Poison</td>
+        <td>
+          <label>poison</label>
+        </td>
+        <td>Green</td>
+      </tr>
+      <tr>
+        <td>
+          <label>5</label>
+        </td>
+        <td>Potion of Healing</td>
+        <td>
+          <label>instant_health</label>
+        </td>
+        <td>Red</td>
+      </tr>
+      <tr>
+        <td>
+          <label>6</label>
+        </td>
+        <td>Potion of Night Vision</td>
+        <td>
+          <label>night_vision</label>
+        </td>
+        <td>Navy Blue</td>
+      </tr>
+      <tr>
+        <td>
+          <label>7</label>
+        </td>
+        <td>Clear Potion</td>
+        <td>
+          <label>N/A</label>
+        </td>
+        <td>Blue</td>
+      </tr>
+      <tr>
+        <td>
+          <label>8</label>
+        </td>
+        <td>Potion of Weakness</td>
+        <td>
+          <label>weakness</label>
+        </td>
+        <td>Gray</td>
+      </tr>
+      <tr>
+        <td>
+          <label>9</label>
+        </td>
+        <td>Potion of Strength</td>
+        <td>
+          <label>strength</label>
+        </td>
+        <td>Dark Red</td>
+      </tr>
+      <tr>
+        <td>
+          <label>10</label>
+        </td>
+        <td>Potion of Slowness</td>
+        <td>
+          <label>slowness</label>
+        </td>
+        <td>Blue-gray</td>
+      </tr>
+      <tr>
+        <td>
+          <label>11</label>
+        </td>
+        <td>Potion of Leaping</td>
+        <td>
+          <label>jump_boost</label>
+        </td>
+        <td>Bright Green</td>
+      </tr>
+      <tr>
+        <td>
+          <label>12</label>
+        </td>
+        <td>Potion of Harming</td>
+        <td>
+          <label>instant_damage</label>
+        </td>
+        <td>Purple</td>
+      </tr>
+      <tr>
+        <td>
+          <label>13</label>
+        </td>
+        <td>Potion of Water Breathing</td>
+        <td>
+          <label>N/A</label>
+        </td>
+        <td>Blue</td>
+      </tr>
+      <tr>
+        <td>
+          <label>14</label>
+        </td>
+        <td>Potion of Invisibility</td>
+        <td>
+          <label>invisibility</label>
+        </td>
+        <td>Light Gray</td>
+      </tr>
+      <tr>
+        <td>
+          <label>15</label>
+        </td>
+        <td>Thin Potion</td>
+        <td>
+          <label>N/A</label>
+        </td>
+        <td>Blue</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Splash Potions
+
+Splash potions are determined by adding the damage value `16384` to the chosen potion value.
+
+```xml
+<!-- 16384 + 18 = 16402 -->
+<!-- Splash potion + Speed color = Splash Potion of Swiftness I -->
+<item amount="1" material="potion" damage="16402">
+    <!-- Overwrites original three minute Speed I effect -->
+    <effect duration="1m" amplifier="2">speed</effect>
+</item>
+```

--- a/docs/reference/items/potions.mdx
+++ b/docs/reference/items/potions.mdx
@@ -5,9 +5,8 @@ title: Potions & Effects
 
 ### Potion Names & Colors
 
-Damage values for potion names/colors, and their effect names to set [potion effects](/docs/modules/gear/potions).
-Damage values set the potion color, potion type, default duration and name.
-Use the `<effect>` element to set custom duration, amplifier, and actual potion effect.
+Damage values set the potion color, [potion effect](/docs/modules/gear/potions), default duration and name for potion items.
+Use the `<effect>` element to set custom duration, amplifier and desired potion effect.
 
 <div className="table-container">
   <table>

--- a/docs/reference/items/potions.mdx
+++ b/docs/reference/items/potions.mdx
@@ -5,9 +5,9 @@ title: Potions & Effects
 
 ### Potion Names & Colors
 
-Damage values for potion names/colors, and their effect names for `<effect>`.
-These are intended for use to set the potion color, potion type, and default name.
-Use the `<effect>` element to set duration, amplifier, custom name, and actual potion effect.
+Damage values for potion names/colors, and their effect names to set [potion effects](/docs/modules/gear/potions).
+Damage values set the potion color, potion type, default duration and name.
+Use the `<effect>` element to set custom duration, amplifier, and actual potion effect.
 
 <div className="table-container">
   <table>
@@ -191,13 +191,13 @@ Splash potions are determined by adding the damage value `16384` to the chosen p
 ```xml
 <!-- 16384 + 18 = 16402 -->
 <!-- Splash potion + Speed color = Splash Potion of Swiftness I -->
-<item amount="1" material="potion" damage="16402">
+<item amount="1" material="potion" damage="16402" name="Super Speed">
     <!-- Overwrites original three minute Speed I effect -->
     <effect duration="1m" amplifier="2">speed</effect>
 </item>
 
 <!-- 16384 + 5 = 16389 -->
-<!-- Splash potion + Speed color = Splash Potion of Instant Health I -->
+<!-- Splash potion + Healing color = Splash Potion of Instant Health I -->
 <item amount="1" material="potion" damage="16389">
     <effect amplifier="1">instant_health</effect>
 </item>

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,6 +56,7 @@ module.exports = {
   Reference: {
     Items: [
       "reference/items/inventory",
+      "reference/items/potions",
       "reference/items/enchantments",
       "reference/items/attributes",
     ],


### PR DESCRIPTION
- Adds potions reference page for damage values, splash potions as damage value determines potion colour.
- Update links to reference the reference page
- Updates potion examples, adds examples for splash potions.

The documentation might change depending on weather this gets merged, which I will update once this is dealt with.

https://github.com/PGMDev/PGM/pull/715