### PR TITLE
Add Introduction Page

### DIFF
--- a/docs/modules/general/introduction.mdx
+++ b/docs/modules/general/introduction.mdx
@@ -5,25 +5,25 @@ title: Introduction
 
 ### History
 
-PGM originally started off in 2012 as a single game plugin specificaly built to run one map, Airship Battle.
+PGM originally started in 2012 as a single game plugin specifically built to run one map, Airship Battle.
 This plugin could manage the match and reset the map easily at the end of the game.
-Other maps were created later, but these all had to be hardcoded into the plugin.
+Other maps were created later, but these all had to be hard-coded into the plugin.
 This was cumbersome and complicated, and there needed to be a new way to quickly program maps into the plugin using an easy to understand language and syntax.
 This problem would later meet its solution, the PvP Game Manager.
 Players unknown to Java programming could now create their own games and matches using an XML file that PGM takes as an input.
-As of now, there are around 1000+ maps made for PGM!
+As of now, there are over 1000 maps made for PGM!
 
 ### How it Works
 
-All maps made for PGM are programmed using an XML file called `map.xml`.
-XML is structured and layered silimar to HTML, making it easily readable.
-Everything from objectives, spawn kits, filters, jump pads, build areas, kill rewards and damage disable is defined in a map's XML file.
+All maps made for PGM are configured using an XML file called `map.xml`.
+XML is structured and layered similar to HTML, making it easily readable.
+Everything from objectives, spawn kits, filters, jump pads, build areas, kill rewards is defined in a map's XML file.
 Most of the XML can be programmed with little involvement of Minecraft, save for testing and getting coordinates.
 PGM is also backwards compatible with XML files that were made for a previous spec (map proto) so older maps don't need to be upgraded to be playable.
 
-Aspects to a map are defined by modules, and information can be placed inside and in-between modules.
+Aspects of a map are defined by modules, and information can be placed inside modules.
 
 Take a look at an [example](/docs/examples/airship-battle) to see how the XML works and how the modules work together.
 
 The rest of this documentation will explain how to use the modules to build a working XML file for your map.
-Any text editor of your choice can be used to write XML files.
+Text editors like [Atom](https://atom.io/), and [Sublime Text](https://www.sublimetext.com/) are good choices to edit XML.

--- a/docs/modules/general/introduction.mdx
+++ b/docs/modules/general/introduction.mdx
@@ -13,9 +13,8 @@ This problem would later meet its solution, the PvP Game Manager.
 Players unknown to Java programming could now create their own games and matches using an XML file that PGM takes as an input.
 
 This was the signature plugin that was exclusive to a major Minecraft server called Overcast Network (also known as oc.tc).
-After the server's closure, it was open sourced for the community to enjoy.
-A new server called Stratus Network became the lead maintainer of PGM, adding new features to it, but later on they were unable to maintain the plugin as it became large and messy.
-This current iteration of PGM has been forked from a pre-Stratus version to heavily simplify its scope and has three major changes from the previous versions.
+After the server's closure, it was open sourced for the community to enjoy, but at that point it became very complex to maintain and use.
+This current iteration of PGM has been forked from an earlier 1.8 copy to heavily simplify its scope and has three major changes from the previous iterations of PGM.
 
 - Based on Minecraft 1.8
 - No backend, website or API

--- a/docs/modules/general/introduction.mdx
+++ b/docs/modules/general/introduction.mdx
@@ -1,0 +1,29 @@
+---
+id: introduction
+title: Introduction
+---
+
+### History
+
+PGM originally started off in 2012 as a single game plugin specificaly built to run one map, Airship Battle.
+This plugin could manage the match and reset the map easily at the end of the game.
+Other maps were created later, but these all had to be hardcoded into the plugin.
+This was cumbersome and complicated, and there needed to be a new way to quickly program maps into the plugin using an easy to understand language and syntax.
+This problem would later meet its solution, the PvP Game Manager.
+Players unknown to Java programming could now create their own games and matches using an XML file that PGM takes as an input.
+As of now, there are around 1000+ maps made for PGM!
+
+### How it Works
+
+All maps made for PGM are programmed using an XML file called `map.xml`.
+XML is structured and layered silimar to HTML, making it easily readable.
+Everything from objectives, spawn kits, filters, jump pads, build areas, kill rewards and damage disable is defined in a map's XML file.
+Most of the XML can be programmed with little involvement of Minecraft, save for testing and getting coordinates.
+PGM is also backwards compatible with XML files that were made for a previous spec (map proto) so older maps don't need to be upgraded to be playable.
+
+Aspects to a map are defined by modules, and information can be placed inside and in-between modules.
+
+Take a look at an [example](/docs/examples/airship-battle) to see how the XML works and how the modules work together.
+
+The rest of this documentation will explain how to use the modules to build a working XML file for your map.
+Any text editor of your choice can be used to write XML files.

--- a/docs/modules/general/introduction.mdx
+++ b/docs/modules/general/introduction.mdx
@@ -6,24 +6,34 @@ title: Introduction
 ### History
 
 PGM originally started in 2012 as a single game plugin specifically built to run one map, Airship Battle.
-This plugin could manage the match and reset the map easily at the end of the game.
+This plugin could manage the match and reset the map easily at the end of the game, which was unique at the time as there were no comprehensive Bukkit plugins that could manage PvP matches.
 Other maps were created later, but these all had to be hard-coded into the plugin.
 This was cumbersome and complicated, and there needed to be a new way to quickly program maps into the plugin using an easy to understand language and syntax.
 This problem would later meet its solution, the PvP Game Manager.
 Players unknown to Java programming could now create their own games and matches using an XML file that PGM takes as an input.
-As of now, there are over 1000 maps made for PGM!
+This was the signature plugin that was exclusive to a major Minecraft server called Overcast Network (also known as oc.tc).
+After the server's clousure, it was open sourced for the community to enjoy.
+A new server called Stratus Network became the lead maintainer of PGM, adding new features to it, but later on they became unable to maintain the plugin as it became large and messy.
+This current iteration of PGM has been rebuilt to heavily simplify its scope and has three major changes from the previous versions.
+
+- Based on Minecraft 1.8
+- No backend, website or API
+- Reduced dependencies to make it easier to compile and submit contributions.
+  It is now a lot easier for anyone to run a Minecraft server using PGM and people are still making new maps for it.
+  As of now, there are over 1000 maps made for PGM!
 
 ### How it Works
 
-All maps made for PGM are configured using an XML file called `map.xml`.
+All maps made for PGM are configured using a unique XML file called `map.xml`.
 XML is structured and layered similar to HTML, making it easily readable.
-Everything from objectives, spawn kits, filters, jump pads, build areas, kill rewards is defined in a map's XML file.
+PGM reads `map.xml` when the server is loaded, and when the match starts it applies all the functions that is defined in the XML file onto the map.
+Everything from objectives, spawn kits, filters, jump pads, and kill rewards is defined in a map's XML file.
+Many different gamemodes can be made with PGM, like Team Deathmatch, Capture the Wool, Race, Destroy the Monument, Attack and Defend, and King of the Hill.
+Aspects of a map are defined by modules, and information can be placed inside other modules, making them very versitile and can be used to create many other unique gamemodes and maps.
 Most of the XML can be programmed with little involvement of Minecraft, save for testing and getting coordinates.
+
+Take a look at this [example](/docs/examples/airship-battle) to see how `map.xml` works and how the modules work together.
 PGM is also backwards compatible with XML files that were made for a previous spec (map proto) so older maps don't need to be upgraded to be playable.
-
-Aspects of a map are defined by modules, and information can be placed inside modules.
-
-Take a look at an [example](/docs/examples/airship-battle) to see how the XML works and how the modules work together.
 
 The rest of this documentation will explain how to use the modules to build a working XML file for your map.
 Text editors like [Atom](https://atom.io/), and [Sublime Text](https://www.sublimetext.com/) are good choices to edit XML.

--- a/docs/modules/general/introduction.mdx
+++ b/docs/modules/general/introduction.mdx
@@ -14,11 +14,13 @@ Players unknown to Java programming could now create their own games and matches
 
 This was the signature plugin that was exclusive to a major Minecraft server called Overcast Network (also known as oc.tc).
 After the server's closure, it was open sourced for the community to enjoy.
-A new server called Stratus Network became the lead maintainer of PGM, adding new features to it, but later on they became unable to maintain the plugin as it became large and messy.
-This current iteration of PGM has been forked from an pre-Stratus version to heavily simplify its scope and has three major changes from the previous versions.
+A new server called Stratus Network became the lead maintainer of PGM, adding new features to it, but later on they were unable to maintain the plugin as it became large and messy.
+This current iteration of PGM has been forked from a pre-Stratus version to heavily simplify its scope and has three major changes from the previous versions.
+
 - Based on Minecraft 1.8
 - No backend, website or API
 - Reduced dependencies to make it easier to compile and submit contributions.
+
 It is now easier for anyone to run a Minecraft server using PGM, and people are still making new maps with new features coming in.
 As of now, there are over 1000 maps made for PGM!
 
@@ -26,7 +28,7 @@ As of now, there are over 1000 maps made for PGM!
 
 All maps made for PGM are configured using a unique XML file called `map.xml`.
 XML is structured and layered similar to HTML, making it easily readable.
-PGM reads `map.xml` when the server is loaded, and when the match starts it applies all the functions that is defined in the XML file onto the map.
+PGM reads `map.xml` when the server is loaded, and when the match starts it applies all the functions that is defined in the XML file onto the game.
 Everything from objectives, spawn kits, filters, jump pads, and kill rewards is defined in a map's XML file.
 Many different game modes can be reproduced with PGM, like Team Deathmatch, Capture the Wool, Race, Destroy the Monument, Attack and Defend, and King of the Hill.
 Aspects of a map are defined by modules, and information can be placed inside other modules, making them very versatile and can be used to create many other unique game modes and maps.
@@ -36,6 +38,6 @@ Take a look at this [example](/docs/examples/airship-battle) to see how `map.xml
 PGM is also backwards compatible with XML files that were made for a previous spec (map proto) so older maps don't need to be upgraded to be playable.
 
 The rest of this documentation will explain how to use the modules to build a working XML file for your map.
-Text editors like [Atom](https://atom.io/), and [Sublime Text](https://www.sublimetext.com/) are good choices to edit XML.
+Text editors like [Atom](https://atom.io/) and [Sublime Text](https://www.sublimetext.com/) are good choices to edit XML.
 
 Let's [get started!](/docs/modules/general/main/)

--- a/docs/modules/general/introduction.mdx
+++ b/docs/modules/general/introduction.mdx
@@ -5,22 +5,22 @@ title: Introduction
 
 ### History
 
-PGM originally started in 2012 as a single game plugin specifically built to run one map, Airship Battle.
+PGM originally started in 2012 as a single game plugin specifically built to run one map, [Airship Battle](https://youtu.be/3dLo8ytygWs).
 This plugin could manage the match and reset the map easily at the end of the game, which was unique at the time as there were no comprehensive Bukkit plugins that could manage PvP matches.
 Other maps were created later, but these all had to be hard-coded into the plugin.
 This was cumbersome and complicated, and there needed to be a new way to quickly program maps into the plugin using an easy to understand language and syntax.
 This problem would later meet its solution, the PvP Game Manager.
 Players unknown to Java programming could now create their own games and matches using an XML file that PGM takes as an input.
-This was the signature plugin that was exclusive to a major Minecraft server called Overcast Network (also known as oc.tc).
-After the server's clousure, it was open sourced for the community to enjoy.
-A new server called Stratus Network became the lead maintainer of PGM, adding new features to it, but later on they became unable to maintain the plugin as it became large and messy.
-This current iteration of PGM has been rebuilt to heavily simplify its scope and has three major changes from the previous versions.
 
+This was the signature plugin that was exclusive to a major Minecraft server called Overcast Network (also known as oc.tc).
+After the server's closure, it was open sourced for the community to enjoy.
+A new server called Stratus Network became the lead maintainer of PGM, adding new features to it, but later on they became unable to maintain the plugin as it became large and messy.
+This current iteration of PGM has been forked from an pre-Stratus version to heavily simplify its scope and has three major changes from the previous versions.
 - Based on Minecraft 1.8
 - No backend, website or API
 - Reduced dependencies to make it easier to compile and submit contributions.
-  It is now a lot easier for anyone to run a Minecraft server using PGM and people are still making new maps for it.
-  As of now, there are over 1000 maps made for PGM!
+It is now easier for anyone to run a Minecraft server using PGM, and people are still making new maps with new features coming in.
+As of now, there are over 1000 maps made for PGM!
 
 ### How it Works
 
@@ -28,8 +28,8 @@ All maps made for PGM are configured using a unique XML file called `map.xml`.
 XML is structured and layered similar to HTML, making it easily readable.
 PGM reads `map.xml` when the server is loaded, and when the match starts it applies all the functions that is defined in the XML file onto the map.
 Everything from objectives, spawn kits, filters, jump pads, and kill rewards is defined in a map's XML file.
-Many different gamemodes can be made with PGM, like Team Deathmatch, Capture the Wool, Race, Destroy the Monument, Attack and Defend, and King of the Hill.
-Aspects of a map are defined by modules, and information can be placed inside other modules, making them very versitile and can be used to create many other unique gamemodes and maps.
+Many different game modes can be reproduced with PGM, like Team Deathmatch, Capture the Wool, Race, Destroy the Monument, Attack and Defend, and King of the Hill.
+Aspects of a map are defined by modules, and information can be placed inside other modules, making them very versatile and can be used to create many other unique game modes and maps.
 Most of the XML can be programmed with little involvement of Minecraft, save for testing and getting coordinates.
 
 Take a look at this [example](/docs/examples/airship-battle) to see how `map.xml` works and how the modules work together.
@@ -37,3 +37,5 @@ PGM is also backwards compatible with XML files that were made for a previous sp
 
 The rest of this documentation will explain how to use the modules to build a working XML file for your map.
 Text editors like [Atom](https://atom.io/), and [Sublime Text](https://www.sublimetext.com/) are good choices to edit XML.
+
+Let's [get started!](/docs/modules/general/main/)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
           position: "left",
           items: [
             {
-              to: "docs/modules/general/main",
+              to: "docs/modules/general/introduction",
               label: "Modules",
             },
             {

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
   Modules: {
-    General: ["modules/general/main"],
+    General: ["modules/general/introduction", "modules/general/main"],
     Information: [
       "modules/information/broadcasts",
       "modules/information/rules",


### PR DESCRIPTION
Signed-off-by: Patrick <cowinkkeydinkinc@gmail.com>

Adds an Introduction Page to the Modules section. This introduction gives a short history and explanation of what an XML file is and what it can do. It links to the Airship Battles example which already explains nicely how a simple map is structured.

There's still a few more changes I want to do, expand on the history and make the introduction the default page when opening the modules tab, which I couldn't figure out on this small laptop.