### PR TITLE
Fix owner-points name

### DIFF
--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -141,7 +141,7 @@ Control point give a certain amount of point to the team currently holding it. O
       </tr>
       <tr>
         <td>
-          <label>points-owner</label>
+          <label>owner-points</label>
         </td>
         <td>
           Gives a set number of points to a team when captured. When the control


### PR DESCRIPTION
Signed-off-by: Patrick <cowinkkeydinkinc@gmail.com>

I accidentally gave them the wrong name in the documentation, PGM refers to it as points owner when in XML it uses `owner-points`.