### PR TITLE
Add documentation for mode IDs

### DIFF
--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -170,7 +170,7 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
         <td>
           Specify which{" "}
           <a href="/docs/modules/objectives/monument-modes">monument modes</a>{" "}
-          should be used.
+          should be used. Multiple modes are seperated with a space.
         </td>
         <td>
           <a href="/docs/modules/objectives/monument-modes">Mode IDs</a>
@@ -182,7 +182,7 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
           <label>mode-changes</label>
         </td>
         <td>
-          Specify if this core uses custom monument modes.
+          Specify if this core uses monument modes.
           <br />
           <label>NOTE:</label>
           Not used in conjunction with <label>modes</label>.
@@ -190,7 +190,7 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
         <td>
           <span className="badge badge--primary">true/false</span>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr>
       <tr>
         <td>

--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -3,7 +3,10 @@ id: dtc
 title: Destroy the Core
 ---
 
-Players have to locate and break the enemy team's core, usually an obsidian sphere filled with lava. The lava has to leak down a certain distance for the core to be destroyed. Lava should not be available anywhere else on the map, otherwise a core leak could be faked. This can also be avoided by keeping the lava far away enough from the core and not giving players buckets or the ability to craft them.
+Players have to locate and break the enemy team's core, usually an obsidian sphere filled with lava.
+The lava has to leak down a certain distance for the core to be destroyed.
+Lava should not be available anywhere else on the map, otherwise a core leak could be faked.
+This can also be avoided by keeping the lava far away enough from the core and not giving players buckets or the ability to craft them.
 
 <div className="table-container">
   <table>
@@ -170,7 +173,7 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
         <td>
           Specify which{" "}
           <a href="/docs/modules/objectives/monument-modes">monument modes</a>{" "}
-          should be used. Multiple modes are seperated with a space.
+          should be used. Multiple modes are separated with a space.
         </td>
         <td>
           <a href="/docs/modules/objectives/monument-modes">Mode IDs</a>

--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -159,7 +159,7 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
           Team the core belongs to, i.e. its owner.
         </td>
         <td>
-          <a href="/docs/modules/objectives/teams">Team ID</a>
+          <a href="/docs/modules/format/teams">Team ID</a>
         </td>
         <td />
       </tr>

--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -159,22 +159,38 @@ Players have to locate and break the enemy team's core, usually an obsidian sphe
           Team the core belongs to, i.e. its owner.
         </td>
         <td>
-          <a href="/docs/modules/format/teams">Team ID</a>
+          <a href="/docs/modules/objectives/teams">Team ID</a>
         </td>
         <td />
+      </tr>
+      <tr>
+        <td>
+          <label>modes</label>
+        </td>
+        <td>
+          Specify which{" "}
+          <a href="/docs/modules/objectives/monument-modes">monument modes</a>{" "}
+          should be used.
+        </td>
+        <td>
+          <a href="/docs/modules/objectives/monument-modes">Mode IDs</a>
+        </td>
+        <td>All modes.</td>
       </tr>
       <tr>
         <td>
           <label>mode-changes</label>
         </td>
         <td>
-          Specify if this core uses{" "}
-          <a href="/docs/modules/objectives/monument-modes">monument modes</a>
+          Specify if this core uses custom monument modes.
+          <br />
+          <label>NOTE:</label>
+          Not used in conjunction with <label>modes</label>.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
         </td>
-        <td />
+        <td>true</td>
       </tr>
       <tr>
         <td>

--- a/docs/modules/objectives/dtm.mdx
+++ b/docs/modules/objectives/dtm.mdx
@@ -164,7 +164,7 @@ Completion specifies how much of the material(s) inside of the monument region m
         <td>
           Specify which{" "}
           <a href="/docs/modules/objectives/monument-modes">monument modes</a>{" "}
-          should be used. Multiple modes are seperated with a space.
+          should be used. Multiple modes are separated with a space.
         </td>
         <td>
           <a href="/docs/modules/objectives/monument-modes">Mode IDs</a>

--- a/docs/modules/objectives/dtm.mdx
+++ b/docs/modules/objectives/dtm.mdx
@@ -159,16 +159,32 @@ Completion specifies how much of the material(s) inside of the monument region m
       </tr>
       <tr>
         <td>
+          <label>modes</label>
+        </td>
+        <td>
+          Specify which{" "}
+          <a href="/docs/modules/objectives/monument-modes">monument modes</a>{" "}
+          should be used.
+        </td>
+        <td>
+          <a href="/docs/modules/objectives/monument-modes">Mode IDs</a>
+        </td>
+        <td>All modes.</td>
+      </tr>
+      <tr>
+        <td>
           <label>mode-changes</label>
         </td>
         <td>
-          Specify if this destroyable uses custom{" "}
-          <a href="/docs/modules/objectives/monument-modes">monument modes</a>
+          Specify if this destroyable uses custom monument modes.
+          <br />
+          <label>NOTE:</label>
+          Not used in conjunction with <label>modes</label>.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
         </td>
-        <td>false</td>
+        <td>true</td>
       </tr>
       <tr>
         <td>
@@ -228,7 +244,7 @@ Completion specifies how much of the material(s) inside of the monument region m
         <td>
           Metric used to determine proximity to the destroyable.
           <br />
-          Accepts <label>closest player</label>, <label>closest block</label>, {" "}
+          Accepts <label>closest player</label>, <label>closest block</label>,{" "}
           <label>closest kill</label> or <label>none</label>.
         </td>
         <td>

--- a/docs/modules/objectives/dtm.mdx
+++ b/docs/modules/objectives/dtm.mdx
@@ -164,7 +164,7 @@ Completion specifies how much of the material(s) inside of the monument region m
         <td>
           Specify which{" "}
           <a href="/docs/modules/objectives/monument-modes">monument modes</a>{" "}
-          should be used.
+          should be used. Multiple modes are seperated with a space.
         </td>
         <td>
           <a href="/docs/modules/objectives/monument-modes">Mode IDs</a>
@@ -176,7 +176,7 @@ Completion specifies how much of the material(s) inside of the monument region m
           <label>mode-changes</label>
         </td>
         <td>
-          Specify if this destroyable uses custom monument modes.
+          Specify if this destroyable uses monument modes.
           <br />
           <label>NOTE:</label>
           Not used in conjunction with <label>modes</label>.
@@ -184,7 +184,7 @@ Completion specifies how much of the material(s) inside of the monument region m
         <td>
           <span className="badge badge--primary">true/false</span>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr>
       <tr>
         <td>

--- a/docs/modules/objectives/monument-modes.mdx
+++ b/docs/modules/objectives/monument-modes.mdx
@@ -129,7 +129,7 @@ Each `<mode>` has configurable characteristics that define it.
 #### Examples
 
 This specifies a mode that will change the material of affected objectives
-to gold block after 10 minutes of gameplay.
+to gold blocks after ten minutes of gameplay.
 
 ```xml
 <modes>
@@ -144,19 +144,26 @@ modes, regardless if the mode has an ID.
 
 ```xml
 <destroyables name="Monument" materials="obsidian" mode-changes="true">
-    <!-- destroyables... -->
-    <!-- destroyables are already affected by modes listed in core -->
+    <destroyable owner="red" mode-changes="true">
+        <region><cuboid min="46,16,26" max="45,14,25"/></region>
+    </destroyable>
+    <!-- destroyable is already affected by modes listed -->
 </destroyable>
 <cores>
     <core team="red" modes="gold-mode sandstone-mode glass-mode">
         <region><cuboid min="10,15,12" max="12,13,16"/></region>
     </core>
 </cores>
+<modes>
+    <mode after="5m" material="gold block" id="gold-mode"/>
+    <mode after="10m" material="sandstone" id="sandstone-mode"/>
+    <mode after="15m" material="glass" id="glass-mode"/>
+</modes>
 ```
 
-This specifies a mode that will change the material of affected objectives to
-coal blocks after 10 minutes of gameplay, with the following boss bar message
-in yellow, `> > > EASY MODE < < <`
+This shows a mode that will change the material of enabled objectives to
+coal blocks after ten minutes of gameplay. The following text, `> > > EASY MODE < < <`
+will be on top of the BossBar in yellow.
 
 ```xml
 <modes>
@@ -166,7 +173,7 @@ in yellow, `> > > EASY MODE < < <`
 
 In this example, the two cores and the two monuments turn to glass in ten minutes, and the
 two cores will turn to gold in fifteen minutes. Enabling an objective's `mode-changes`
-attribute is not necessary in this senario.
+attribute is not necessary in this case.
 
 ```xml
 <cores>

--- a/docs/modules/objectives/monument-modes.mdx
+++ b/docs/modules/objectives/monument-modes.mdx
@@ -137,8 +137,26 @@ to gold block after 10 minutes of gameplay.
 </modes>
 ```
 
+In order for an objective to change modes,
+it must have `modes` or `mode-changes="true"` in its element tag.
+Objectives with `mode-changes` enabled will cycle through all
+modes, regardless if the mode has an ID.
+
+```xml
+<destroyables name="Monument" materials="obsidian" mode-changes="true">
+    <!-- destroyables... -->
+    <!-- destroyables are already affected by modes listed in core -->
+</destroyable>
+<cores>
+    <core team="red" modes="gold-mode sandstone-mode glass-mode">
+        <region><cuboid min="10,15,12" max="12,13,16"/></region>
+    </core>
+</cores>
+```
+
 This specifies a mode that will change the material of affected objectives to
-coal blocks after 10 minutes of gameplay, with the following status message, `> > > EASY MODE < < <`
+coal blocks after 10 minutes of gameplay, with the following boss bar message
+in yellow, `> > > EASY MODE < < <`
 
 ```xml
 <modes>
@@ -147,28 +165,20 @@ coal blocks after 10 minutes of gameplay, with the following status message, `> 
 ```
 
 In this example, the two cores and the two monuments turn to glass in ten minutes, and the
-two cores will turn to gold in fifteen minutes.
+two cores will turn to gold in fifteen minutes. Enabling an objective's `mode-changes`
+attribute is not necessary in this senario.
 
 ```xml
-<cores material="obsidian" leak="2">
-    <core team="red-team" region="left-core" modes="glass-mode gold-mode" name="red core"/>
-    <core team="blue-team" region="right-core" modes="glass-mode gold-mode" name="blue core"/>
+<cores>
+    <core team="red-team"  region="red-core" modes="glass-mode gold-mode"/>
+    <core team="blue-team" region="blu-core" modes="glass-mode gold-mode"/>
 </cores>
-<destroyables>
-    <destroyable id="red-mon" name="red one" owner="red-team" modes="glass-mode" region="mon-red" materials="obsidian"/>
-    <destroyable id="blue-mon" name="blue one" owner="blue-team" modes="glass-mode" region="mon-blu" materials="obsidian"/>
+<destroyables materials="obsidian">
+    <destroyable owner="red-team" modes="glass-mode" region="mon-red" name="Red Monument"/>
+    <destroyable owner="blue-team" modes="glass-mode" region="mon-blu" name="Blue Monument"/>
 </destroyables>
 <modes>
-    <mode id="glass-mode" after="10m" material="glass" name="`eGlass Mode"/>
-    <mode id="gold-mode" after="15m" material="gold block" name="`eGold Mode"/>
+    <mode id="glass-mode" after="10m" material="glass" name="`fGlass Mode"/>
+    <mode id="gold-mode" after="15m" material="gold block" name="`6Gold Mode"/>
 </modes>
-```
-
-`NOTE:` In order for an objective to change modes, it must
-have `modes` or `mode-changes="true"` in its element tag.
-
-```xml
-<destroyables name="Monument" materials="obsidian" mode-changes="true">
-    <!-- destroyables... -->
-</destroyable>
 ```

--- a/docs/modules/objectives/monument-modes.mdx
+++ b/docs/modules/objectives/monument-modes.mdx
@@ -7,7 +7,7 @@ This module can be used to customize the modes that cores and destroyables cycle
 through, and at what duration they do so. When a monuments mode changes its
 material is usually changed from a hard to a soft block.
 
-The `<modes>` tag can contain any number of `<mode>` tags with different durations.
+The `<modes>` tag can contain any number of `<mode>` tags at any duration, even at the same time.
 Each `<mode>` has configurable characteristics that define it.
 
 <div className="table-container">

--- a/docs/modules/objectives/monument-modes.mdx
+++ b/docs/modules/objectives/monument-modes.mdx
@@ -3,9 +3,12 @@ id: monument-modes
 title: Monument Modes
 ---
 
-This module can be used to customize the modes that cores and destroyables cycle through, and at what duration they do so. When a monuments mode changes its material is usually changed from a hard to a soft block.
+This module can be used to customize the modes that cores and destroyables cycle
+through, and at what duration they do so. When a monuments mode changes its
+material is usually changed from a hard to a soft block.
 
-The `<modes>` tag can contain any number of `<mode>` tags with different durations. Each `<mode>` has configurable characteristics that define it.
+The `<modes>` tag can contain any number of `<mode>` tags with different durations.
+Each `<mode>` has configurable characteristics that define it.
 
 <div className="table-container">
   <table>
@@ -86,6 +89,16 @@ The `<modes>` tag can contain any number of `<mode>` tags with different duratio
       </tr>
       <tr>
         <td>
+          <label>id</label>
+        </td>
+        <td>The unique ID of the mode.</td>
+        <td>
+          <span className="badge badge--primary">String</span>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
           <label>name</label>
         </td>
         <td>Custom mode name, used for the mode change notice.</td>
@@ -112,7 +125,11 @@ The `<modes>` tag can contain any number of `<mode>` tags with different duratio
     </tbody>
   </table>
 </div>
-Example
+
+#### Examples
+
+This specifies a mode that will change the material of affected objectives
+to gold block after 10 minutes of gameplay.
 
 ```xml
 <modes>
@@ -120,7 +137,8 @@ Example
 </modes>
 ```
 
-This specifies a mode that will change the material of affected objectives to gold block after 10 minutes of gameplay.
+This specifies a mode that will change the material of affected objectives to
+coal blocks after 10 minutes of gameplay, with the following status message, `> > > EASY MODE < < <`
 
 ```xml
 <modes>
@@ -128,9 +146,26 @@ This specifies a mode that will change the material of affected objectives to go
 </modes>
 ```
 
-This specifies a mode that will change the material of affected objectives to coal block after 10 minutes of gameplay, with the following chat message: `> > > EASY MODE < < <`
+In this example, the two cores and the two monuments turn to glass in ten minutes, and the
+two cores will turn to gold in fifteen minutes.
 
-`NOTE:` In order for an objective to change modes, it must have `mode-changes="true"` in its element tag.
+```xml
+<cores material="obsidian" leak="2">
+    <core team="red-team" region="left-core" modes="glass-mode gold-mode" name="red core"/>
+    <core team="blue-team" region="right-core" modes="glass-mode gold-mode" name="blue core"/>
+</cores>
+<destroyables>
+    <destroyable id="red-mon" name="red one" owner="red-team" modes="glass-mode" region="mon-red" materials="obsidian"/>
+    <destroyable id="blue-mon" name="blue one" owner="blue-team" modes="glass-mode" region="mon-blu" materials="obsidian"/>
+</destroyables>
+<modes>
+    <mode id="glass-mode" after="10m" material="glass" name="`eGlass Mode"/>
+    <mode id="gold-mode" after="15m" material="gold block" name="`eGold Mode"/>
+</modes>
+```
+
+`NOTE:` In order for an objective to change modes, it must
+have `modes` or `mode-changes="true"` in its element tag.
 
 ```xml
 <destroyables name="Monument" materials="obsidian" mode-changes="true">


### PR DESCRIPTION
Adds documentation for mode IDs

- Changes default output of `mode-changes` to true since a null modelist is created in PGM for destroyables with no modes.
- Any objective that does not have `modes` specified will use all monument modes by default.
- Explains `mode-changes` can't be used with `modes`
- Adds example with mode IDs and rearranges text explaining examples.

Currently in PGM, two or more mode changes cannot happen at the same time. I am going to check and see if this is a necessary limitation and document this if it's justified.