### PR TITLE
Fix UUID in custom heads

### DIFF
--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -358,11 +358,10 @@ Items can be give custom names and lore with the `name` and `lore` attributes. C
 
 Player heads can be given to players by using the heads element.
 
-A player's skin data can be found by using `https://sessionserver.mojang.com/session/minecraft/profile/(UUID)`
-There is a limit of one request a minute for each UUID so be sure to copy the data the first time.
+A player's skin data can be found by using `https://sessionserver.mojang.com/session/minecraft/profile/(UUID)`.
 
 ```xml
-<head name="Cubist" uuid="3fbec7dd0a5f40bf9d11885a54507112">
+<head name="Cubist" uuid="3fbec7dd-0a5f-40bf-9d11-885a54507112" slot="slot.armor.head">
     <skin>eyJ0aW1lc3RhbXAiOjE0NDY0MDgwOTExNzQsInByb2ZpbGVJZCI6IjNmYmVjN2RkMGE1ZjQwYmY5ZDExODg1YTU0NTA3MTEyIiwicHJvZmlsZU5hbWUiOiJDdWJpc3QiLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTRlZGExMjg4NWIzYmE2ZGY2ODMyZGZkMTIzNGEyNjc5MmQwNDI2ZDkyMDM2ZWVlYzc1M2ZiZmM2NmRiIn19fQ==</skin>
 </head>
 ```


### PR DESCRIPTION
PGM only uses UUIDs in the 8-4-4-4-12 styling convention, with dashes, it does not take them without any spaces. This also adds an example showing how to put them on a player's head.