### PR TITLE
Add Commands table for PGM, Community and Events plugins

### DIFF
--- a/docs/commands/community.mdx
+++ b/docs/commands/community.mdx
@@ -1,0 +1,512 @@
+---
+id: community
+title: Community Commands
+---
+
+This page describes a list of commands, aliases and permissions for the Community plugin.
+Permissions are prefixed with `CommunityPermissions` (ie `CommunityPermissions.LOOKUP_OTHERS`).
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Commands</th>
+        <th>Aliases</th>
+        <th>Description</th>
+        <th>Useage</th>
+        <th>Permissions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>alts</td>
+        <td>alternateaccounts</td>
+        <td>View a list of alternate accounts of a player</td>
+        <td>[target]</td>
+        <td>LOOKUP_OTHERS</td>
+      </tr>
+      <tr>
+        <td>assistance</td>
+        <td>assist helpop helpme</td>
+        <td>Request help from the staff members</td>
+        <td>[reason] – Let staff know what you need help with</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>ban</td>
+        <td>permban pb</td>
+        <td>Ban a player from the server</td>
+        <td>[player] [reason]</td>
+        <td>BAN</td>
+      </tr>
+      <tr>
+        <td>broadcast</td>
+        <td>announce bc</td>
+        <td>Broadcast an announcement to everyone</td>
+        <td>title [message] or [message]</td>
+        <td>BROADCAST</td>
+      </tr>
+      <tr>
+        <td>chat</td>
+        <td></td>
+        <td>Manage the chat status</td>
+        <td>lock|lockdown slow|slowmode status clear</td>
+        <td>CHAT_MANAGEMENT</td>
+      </tr>
+      <tr>
+        <td>chestedit</td>
+        <td>ce cedit containeredit</td>
+        <td>
+          Edit inventory contents of target block (chest, furnace, dispenser,
+          beacon, etc)
+        </td>
+        <td></td>
+        <td>CONTAINER</td>
+      </tr>
+      <tr>
+        <td>community</td>
+        <td></td>
+        <td>Manage the community plugin</td>
+        <td>reloads by default – stats (punishments|p import true/false)</td>
+        <td>RELOAD</td>
+      </tr>
+      <tr>
+        <td>fly</td>
+        <td>flight</td>
+        <td>Toggle your flight mode</td>
+        <td></td>
+        <td>FLIGHT</td>
+      </tr>
+      <tr>
+        <td>flyspeed</td>
+        <td></td>
+        <td>Adjust your flight speed</td>
+        <td></td>
+        <td>FLIGHT_SPEED</td>
+      </tr>
+      <tr>
+        <td>freeze</td>
+        <td>fz f</td>
+        <td>Toggle a player’s frozen state</td>
+        <td>[username]</td>
+        <td>FREEZE</td>
+      </tr>
+      <tr>
+        <td>friend</td>
+        <td>friendship fs</td>
+        <td>Manage your friend relationships</td>
+        <td></td>
+        <td>FRIENDSHIP</td>
+      </tr>
+      <tr>
+        <td>friend accept</td>
+        <td>acc</td>
+        <td>Accept an incoming friend request</td>
+        <td>[username | uuid]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>friend add</td>
+        <td>request a</td>
+        <td>Sends a friend request to another player</td>
+        <td>[username | uuid]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>friend reject</td>
+        <td>deny</td>
+        <td>Denies an incoming friend request</td>
+        <td>[username | uuid]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>friend remove</td>
+        <td>delete rm</td>
+        <td>Removes a friend</td>
+        <td>[username | uuid]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>friend requests</td>
+        <td>incoming pending</td>
+        <td>View a list of your pending friend requests</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>frozenlist</td>
+        <td>fls flist</td>
+        <td>View a list of frozen players</td>
+        <td></td>
+        <td>FREEZE</td>
+      </tr>
+      <tr>
+        <td>gamemode</td>
+        <td>gm</td>
+        <td>Adjust your or another player’s gamemode</td>
+        <td></td>
+        <td>GAMEODE</td>
+      </tr>
+      <tr>
+        <td>kick</td>
+        <td>k</td>
+        <td>Kick a player from the server</td>
+        <td>[player] [reason]</td>
+        <td>KICK</td>
+      </tr>
+      <tr>
+        <td>languages</td>
+        <td></td>
+        <td>View a list of online languages</td>
+        <td></td>
+        <td>TRANSLATE</td>
+      </tr>
+      <tr>
+        <td>lookup</td>
+        <td>l</td>
+        <td>View infraction history of a player</td>
+        <td>[player] [page]</td>
+        <td>LOOKUP_OTHERS</td>
+      </tr>
+      <tr>
+        <td>modtools</td>
+        <td>mtools</td>
+        <td>Give moderator tools to overserver</td>
+        <td></td>
+        <td>STAFF</td>
+      </tr>
+      <tr>
+        <td>mutate</td>
+        <td>mutation mt</td>
+        <td>Manage match mutations</td>
+        <td></td>
+        <td>MUTATION</td>
+      </tr>
+      <tr>
+        <td>mutate add</td>
+        <td>a</td>
+        <td>Add a mutation to the match</td>
+        <td></td>
+        <td>MUTATION</td>
+      </tr>
+      <tr>
+        <td>mutate list</td>
+        <td>ls</td>
+        <td>View a list of mutations</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>mutate remove</td>
+        <td>rm disable</td>
+        <td>Remove an active mutation from the match</td>
+        <td></td>
+        <td>MUTATION</td>
+      </tr>
+      <tr>
+        <td>mute</td>
+        <td>m</td>
+        <td>Pervent a player from speaking in the chat</td>
+        <td>[player] [duration] [reason]</td>
+        <td>MUTE</td>
+      </tr>
+      <tr>
+        <td>mutes</td>
+        <td></td>
+        <td>List all online players who are muted</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nameban</td>
+        <td>nb</td>
+        <td>
+          Bans a username from the server, player can still reconnect if their
+          username changes
+        </td>
+        <td>[player] – no reason required</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nick</td>
+        <td></td>
+        <td>Set a nickname</td>
+        <td></td>
+        <td>NICKNAME</td>
+      </tr>
+      <tr>
+        <td>nick check</td>
+        <td></td>
+        <td>Check if the provided name is avaliable</td>
+        <td>[nick]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nick clear</td>
+        <td>reset</td>
+        <td>Remove nickname from yourself or another player</td>
+        <td>[target] – needs nickname other permissions</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nick confirm</td>
+        <td></td>
+        <td>Confirm random nickname choice</td>
+        <td>[name] – Confirm name from nick selection</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nick random</td>
+        <td></td>
+        <td>Set a random nickname</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nick set</td>
+        <td></td>
+        <td>Set your nickname</td>
+        <td>[name]</td>
+        <td>NICKNAME_SET</td>
+      </tr>
+      <tr>
+        <td>nick setother</td>
+        <td>other</td>
+        <td>Set the nickname of another player</td>
+        <td>[target] [nick]</td>
+        <td>NICKNAME_OTHER</td>
+      </tr>
+      <tr>
+        <td>nick skin</td>
+        <td></td>
+        <td>Set skin for current nick session</td>
+        <td>[username] – name of skin to copy</td>
+        <td>NICKNAME_SET</td>
+      </tr>
+      <tr>
+        <td>nick status</td>
+        <td></td>
+        <td>Check your current nickname status</td>
+        <td>[target] – needs nickname other permissions</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nick toggle</td>
+        <td></td>
+        <td>Toggle your nickname status</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nicks</td>
+        <td>/nick list</td>
+        <td>View a list of online nicked players</td>
+        <td></td>
+        <td>STAFF</td>
+      </tr>
+      <tr>
+        <td>player</td>
+        <td>pl</td>
+        <td>View a list of recent reports for the targeted player</td>
+        <td>[player] [page]</td>
+        <td>REPORTS</td>
+      </tr>
+      <tr>
+        <td>profile</td>
+        <td>user</td>
+        <td>View account info for a player</td>
+        <td>[name or uuid]</td>
+        <td>LOOKUP_OTHERS</td>
+      </tr>
+      <tr>
+        <td>punishmenthistory</td>
+        <td>ph</td>
+        <td>View a list of recent punishments</td>
+        <td>[page]</td>
+        <td>PUNISH</td>
+      </tr>
+      <tr>
+        <td>queue</td>
+        <td>sponsorqueue sq /sponsor queue</td>
+        <td>View the sponsored maps queue</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>record</td>
+        <td>infractions mypunishments</td>
+        <td>View your punishment histpry</td>
+        <td>[page]</td>
+        <td>LOOKUP</td>
+      </tr>
+      <tr>
+        <td>repeatpunishment</td>
+        <td>rp</td>
+        <td>Repeat the last punishment you performed for another player</td>
+        <td>[player]</td>
+        <td>PUNISH</td>
+      </tr>
+      <tr>
+        <td>report</td>
+        <td></td>
+        <td>Report a player who is breaking the rules</td>
+        <td>[username] [reason]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>reports</td>
+        <td>reporthistory reps</td>
+        <td>View report history</td>
+        <td></td>
+        <td>REPORTS</td>
+      </tr>
+      <tr>
+        <td>request</td>
+        <td>req</td>
+        <td>Request a map</td>
+        <td>[map] – Name of map to request</td>
+        <td>REQUEST</td>
+      </tr>
+      <tr>
+        <td>requests</td>
+        <td>reqs</td>
+        <td>View and manage map requests</td>
+        <td>clear</td>
+        <td>STAFF</td>
+      </tr>
+      <tr>
+        <td>seen</td>
+        <td>lastseen find</td>
+        <td>View when a player was last seen online</td>
+        <td>[player]</td>
+        <td>FIND</td>
+      </tr>
+      <tr>
+        <td>sponsor</td>
+        <td></td>
+        <td>View the sponsor request menu</td>
+        <td>cancel info</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>sponsor maps</td>
+        <td></td>
+        <td>View a list of maps which can be sponsored</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>sponsor request</td>
+        <td>submit add</td>
+        <td>Sponsor a map request</td>
+        <td>[map] – Name of map to sponsor (only allowed maps)</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>staff</td>
+        <td>mods admins</td>
+        <td>View a list of online staff members</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>sudo</td>
+        <td>force</td>
+        <td>Force targets to perform given command</td>
+        <td>[commands]</td>
+        <td>ADMIN</td>
+      </tr>
+      <tr>
+        <td>tempban</td>
+        <td>tb</td>
+        <td>Temporarily bans a player from a server</td>
+        <td>[player] [duration] [reason]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>tokens</td>
+        <td>sponsortokens token</td>
+        <td>View how many sponsor tokens you have</td>
+        <td>balance</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>tokens give</td>
+        <td>award</td>
+        <td>Give the target player sponsor tokens</td>
+        <td>[player] [token amount]</td>
+        <td>ADMIN</td>
+      </tr>
+      <tr>
+        <td>tp</td>
+        <td>teleport</td>
+        <td>Teleport to another player</td>
+        <td>[player]</td>
+        <td>TELEPORT</td>
+      </tr>
+      <tr>
+        <td>tphere</td>
+        <td>bring tph</td>
+        <td>Teleport players to you</td>
+        <td>[player]</td>
+        <td>TELEPORT_OTHERS</td>
+      </tr>
+      <tr>
+        <td>tplocation</td>
+        <td>tpl tploc</td>
+        <td>Teleport to specific coordinates</td>
+        <td>[x,y,z]</td>
+        <td>TELEPORT_LOCATION</td>
+      </tr>
+      <tr>
+        <td>tptarget</td>
+        <td>tptg tg</td>
+        <td>Target a player for the player hook tool</td>
+        <td></td>
+        <td>STAFF</td>
+      </tr>
+      <tr>
+        <td>translate</td>
+        <td></td>
+        <td>Translate the given chat message</td>
+        <td></td>
+        <td>TRANSLATE</td>
+      </tr>
+      <tr>
+        <td>unban</td>
+        <td>pardon forgive</td>
+        <td>Pardon all active punishments for a player</td>
+        <td>[player]</td>
+        <td>UNBAN</td>
+      </tr>
+      <tr>
+        <td>unmute</td>
+        <td>um</td>
+        <td>Unmute a player</td>
+        <td>[player]</td>
+        <td>MUTE</td>
+      </tr>
+      <tr>
+        <td>uptime</td>
+        <td></td>
+        <td>View how long the server has been online</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>usernamehistoy</td>
+        <td>uh</td>
+        <td>View the name history of a user</td>
+        <td>[player]</td>
+        <td>LOOKUP_OTHERS</td>
+      </tr>
+      <tr>
+        <td>warn</td>
+        <td>w</td>
+        <td>Warn a player for bad behavior</td>
+        <td>[player] [reason]</td>
+        <td>WARN</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/commands/community.mdx
+++ b/docs/commands/community.mdx
@@ -3,7 +3,8 @@ id: community
 title: Community Commands
 ---
 
-This page describes a list of commands, aliases and permissions for the Community plugin.
+This page describes a list of commands, aliases and permissions for [Community](https://github.com/PGMDev/Community/), a standalone
+plugin for managing PGM servers. Commands for moderation, punishments, etc will be shown here.
 Permissions are prefixed with `CommunityPermissions` (ie `CommunityPermissions.LOOKUP_OTHERS`).
 
 <div className="table-container">
@@ -19,42 +20,90 @@ Permissions are prefixed with `CommunityPermissions` (ie `CommunityPermissions.L
     </thead>
     <tbody>
       <tr>
-        <td>alts</td>
+        <td>
+          <label>/alts</label>
+        </td>
         <td>alternateaccounts</td>
         <td>View a list of alternate accounts of a player</td>
         <td>[target]</td>
         <td>LOOKUP_OTHERS</td>
       </tr>
       <tr>
-        <td>assistance</td>
+        <td>
+          <label>/assistance</label>
+        </td>
         <td>assist helpop helpme</td>
         <td>Request help from the staff members</td>
         <td>[reason] – Let staff know what you need help with</td>
         <td></td>
       </tr>
       <tr>
-        <td>ban</td>
+        <td>
+          <label>/ban</label>
+        </td>
         <td>permban pb</td>
         <td>Ban a player from the server</td>
         <td>[player] [reason]</td>
         <td>BAN</td>
       </tr>
       <tr>
-        <td>broadcast</td>
+        <td>
+          <label>/broadcast</label>
+        </td>
         <td>announce bc</td>
         <td>Broadcast an announcement to everyone</td>
-        <td>title [message] or [message]</td>
+        <td>[title] [message] or [message]</td>
         <td>BROADCAST</td>
       </tr>
       <tr>
-        <td>chat</td>
+        <td>
+          <label>/chat clear</label>
+        </td>
         <td></td>
-        <td>Manage the chat status</td>
-        <td>lock|lockdown slow|slowmode status clear</td>
+        <td>Clears the chat</td>
+        <td></td>
         <td>CHAT_MANAGEMENT</td>
       </tr>
       <tr>
-        <td>chestedit</td>
+        <td>
+          <label>/chat lock</label>
+        </td>
+        <td>lockdown</td>
+        <td>Toggle lock status for the chat</td>
+        <td></td>
+        <td>CHAT_MANAGEMENT</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/chat slow</label>
+        </td>
+        <td>slowmode</td>
+        <td>Toggle chat slowmode</td>
+        <td></td>
+        <td>CHAT_MANAGEMENT</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/chat status</label>
+        </td>
+        <td></td>
+        <td>View current chat mode status</td>
+        <td></td>
+        <td>CHAT_MANAGEMENT</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/chat</label>
+        </td>
+        <td></td>
+        <td>Manage the chat status</td>
+        <td>defaults to status</td>
+        <td>CHAT_MANAGEMENT</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/chestedit</label>
+        </td>
         <td>ce cedit containeredit</td>
         <td>
           Edit inventory contents of target block (chest, furnace, dispenser,
@@ -64,444 +113,626 @@ Permissions are prefixed with `CommunityPermissions` (ie `CommunityPermissions.L
         <td>CONTAINER</td>
       </tr>
       <tr>
-        <td>community</td>
-        <td></td>
-        <td>Manage the community plugin</td>
-        <td>reloads by default – stats (punishments|p import true/false)</td>
+        <td>
+          <label>/community punishments</label>
+        </td>
+        <td>p</td>
+        <td>Imports bans to databse</td>
+        <td>[true/false] – verbose</td>
         <td>RELOAD</td>
       </tr>
       <tr>
-        <td>fly</td>
+        <td>
+          <label>/community reload</label>
+        </td>
+        <td></td>
+        <td>Reloads the community configuration</td>
+        <td></td>
+        <td>RELOAD</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/community stats</label>
+        </td>
+        <td></td>
+        <td>Displays total users, punishments and reports</td>
+        <td></td>
+        <td>RELOAD</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/community</label>
+        </td>
+        <td></td>
+        <td>Manage the community plugin</td>
+        <td>reloads by default</td>
+        <td>RELOAD</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/fly</label>
+        </td>
         <td>flight</td>
         <td>Toggle your flight mode</td>
         <td></td>
         <td>FLIGHT</td>
       </tr>
       <tr>
-        <td>flyspeed</td>
+        <td>
+          <label>/flyspeed</label>
+        </td>
         <td></td>
         <td>Adjust your flight speed</td>
         <td></td>
         <td>FLIGHT_SPEED</td>
       </tr>
       <tr>
-        <td>freeze</td>
+        <td>
+          <label>/freeze</label>
+        </td>
         <td>fz f</td>
         <td>Toggle a player’s frozen state</td>
         <td>[username]</td>
         <td>FREEZE</td>
       </tr>
       <tr>
-        <td>friend</td>
-        <td>friendship fs</td>
-        <td>Manage your friend relationships</td>
+        <td>
+          <label>/friend accept</label>
+        </td>
+        <td>acc</td>
+        <td>Accept an incoming friend request</td>
+        <td>[username | uuid]</td>
+        <td>FRIENDSHIP</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/friend add</label>
+        </td>
+        <td>request a</td>
+        <td>Sends a friend request to another player</td>
+        <td>[username | uuid]</td>
+        <td>FRIENDSHIP</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/friend reject</label>
+        </td>
+        <td>deny</td>
+        <td>Denies an incoming friend request</td>
+        <td>[username | uuid]</td>
+        <td>FRIENDSHIP</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/friend remove</label>
+        </td>
+        <td>delete rm</td>
+        <td>Removes a friend</td>
+        <td>[username | uuid]</td>
+        <td>FRIENDSHIP</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/friend requests</label>
+        </td>
+        <td>incoming pending</td>
+        <td>View a list of your pending friend requests</td>
         <td></td>
         <td>FRIENDSHIP</td>
       </tr>
       <tr>
-        <td>friend accept</td>
-        <td>acc</td>
-        <td>Accept an incoming friend request</td>
-        <td>[username | uuid]</td>
-        <td></td>
+        <td>
+          <label>/friend</label>
+        </td>
+        <td>friendship fs</td>
+        <td>Manage your friend relationships</td>
+        <td>defaults to list</td>
+        <td>FRIENDSHIP</td>
       </tr>
       <tr>
-        <td>friend add</td>
-        <td>request a</td>
-        <td>Sends a friend request to another player</td>
-        <td>[username | uuid]</td>
+        <td>
+          <label>/friends</label>
+        </td>
+        <td>/friend list</td>
+        <td>View a list of friends</td>
         <td></td>
+        <td>FRIENDSHIP</td>
       </tr>
       <tr>
-        <td>friend reject</td>
-        <td>deny</td>
-        <td>Denies an incoming friend request</td>
-        <td>[username | uuid]</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>friend remove</td>
-        <td>delete rm</td>
-        <td>Removes a friend</td>
-        <td>[username | uuid]</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>friend requests</td>
-        <td>incoming pending</td>
-        <td>View a list of your pending friend requests</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>frozenlist</td>
+        <td>
+          <label>/frozenlist</label>
+        </td>
         <td>fls flist</td>
         <td>View a list of frozen players</td>
         <td></td>
         <td>FREEZE</td>
       </tr>
       <tr>
-        <td>gamemode</td>
+        <td>
+          <label>/gamemode</label>
+        </td>
         <td>gm</td>
         <td>Adjust your or another player’s gamemode</td>
         <td></td>
         <td>GAMEODE</td>
       </tr>
       <tr>
-        <td>kick</td>
+        <td>
+          <label>/kick</label>
+        </td>
         <td>k</td>
         <td>Kick a player from the server</td>
         <td>[player] [reason]</td>
         <td>KICK</td>
       </tr>
       <tr>
-        <td>languages</td>
+        <td>
+          <label>/languages</label>
+        </td>
         <td></td>
         <td>View a list of online languages</td>
         <td></td>
         <td>TRANSLATE</td>
       </tr>
       <tr>
-        <td>lookup</td>
+        <td>
+          <label>/lookup</label>
+        </td>
         <td>l</td>
         <td>View infraction history of a player</td>
         <td>[player] [page]</td>
         <td>LOOKUP_OTHERS</td>
       </tr>
       <tr>
-        <td>modtools</td>
+        <td>
+          <label>/modtools</label>
+        </td>
         <td>mtools</td>
         <td>Give moderator tools to overserver</td>
         <td></td>
         <td>STAFF</td>
       </tr>
       <tr>
-        <td>mutate</td>
-        <td>mutation mt</td>
-        <td>Manage match mutations</td>
-        <td></td>
-        <td>MUTATION</td>
-      </tr>
-      <tr>
-        <td>mutate add</td>
+        <td>
+          <label>/mutate add</label>
+        </td>
         <td>a</td>
         <td>Add a mutation to the match</td>
         <td></td>
         <td>MUTATION</td>
       </tr>
       <tr>
-        <td>mutate list</td>
+        <td>
+          <label>/mutate list</label>
+        </td>
         <td>ls</td>
         <td>View a list of mutations</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>mutate remove</td>
+        <td>
+          <label>/mutate remove</label>
+        </td>
         <td>rm disable</td>
         <td>Remove an active mutation from the match</td>
         <td></td>
         <td>MUTATION</td>
       </tr>
       <tr>
-        <td>mute</td>
+        <td>
+          <label>/mutate</label>
+        </td>
+        <td>mutation mt</td>
+        <td>Manage match mutations</td>
+        <td></td>
+        <td>MUTATION</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/mute</label>
+        </td>
         <td>m</td>
         <td>Pervent a player from speaking in the chat</td>
         <td>[player] [duration] [reason]</td>
         <td>MUTE</td>
       </tr>
       <tr>
-        <td>mutes</td>
+        <td>
+          <label>/mutes</label>
+        </td>
         <td></td>
         <td>List all online players who are muted</td>
         <td></td>
-        <td></td>
+        <td>MUTE</td>
       </tr>
       <tr>
-        <td>nameban</td>
-        <td>nb</td>
+        <td>
+          <label>/nameban</label>
+        </td>
+        <td>nb [/ban username/name]</td>
         <td>
           Bans a username from the server, player can still reconnect if their
           username changes
         </td>
-        <td>[player] – no reason required</td>
-        <td></td>
+        <td>[player] [reason] – no reason required</td>
+        <td>BAN</td>
       </tr>
       <tr>
-        <td>nick</td>
+        <td>
+          <label>/nick check</label>
+        </td>
         <td></td>
-        <td>Set a nickname</td>
+        <td>Check if the provided name is avaliable</td>
+        <td>[nick]</td>
+        <td>NICKNAME</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/nick clear</label>
+        </td>
+        <td>reset</td>
+        <td>Remove nickname from yourself or another player</td>
+        <td>
+          [target] (needs NICKNAME_OTHER permissions) – defaults to own player
+        </td>
+        <td>NICKNAME</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/nick confirm</label>
+        </td>
+        <td></td>
+        <td>Confirm random nickname choice</td>
+        <td>[name] – Confirm name from nick selection</td>
+        <td>NICKNAME</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/nick random</label>
+        </td>
+        <td></td>
+        <td>Set a random nickname</td>
         <td></td>
         <td>NICKNAME</td>
       </tr>
       <tr>
-        <td>nick check</td>
-        <td></td>
-        <td>Check if the provided name is avaliable</td>
-        <td>[nick]</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>nick clear</td>
-        <td>reset</td>
-        <td>Remove nickname from yourself or another player</td>
-        <td>[target] – needs nickname other permissions</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>nick confirm</td>
-        <td></td>
-        <td>Confirm random nickname choice</td>
-        <td>[name] – Confirm name from nick selection</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>nick random</td>
-        <td></td>
-        <td>Set a random nickname</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>nick set</td>
+        <td>
+          <label>/nick set</label>
+        </td>
         <td></td>
         <td>Set your nickname</td>
         <td>[name]</td>
         <td>NICKNAME_SET</td>
       </tr>
       <tr>
-        <td>nick setother</td>
+        <td>
+          <label>/nick setother</label>
+        </td>
         <td>other</td>
         <td>Set the nickname of another player</td>
         <td>[target] [nick]</td>
         <td>NICKNAME_OTHER</td>
       </tr>
       <tr>
-        <td>nick skin</td>
+        <td>
+          <label>/nick skin</label>
+        </td>
         <td></td>
         <td>Set skin for current nick session</td>
         <td>[username] – name of skin to copy</td>
         <td>NICKNAME_SET</td>
       </tr>
       <tr>
-        <td>nick status</td>
+        <td>
+          <label>/nick status</label>
+        </td>
         <td></td>
         <td>Check your current nickname status</td>
-        <td>[target] – needs nickname other permissions</td>
+        <td>[target] (needs NICKNAME_OTHER perms) – defaults to own player</td>
         <td></td>
       </tr>
       <tr>
-        <td>nick toggle</td>
+        <td>
+          <label>/nick toggle</label>
+        </td>
         <td></td>
         <td>Toggle your nickname status</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>nicks</td>
+        <td>
+          <label>/nick</label>
+        </td>
+        <td></td>
+        <td>Set a nickname</td>
+        <td></td>
+        <td>NICKNAME</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/nicks</label>
+        </td>
         <td>/nick list</td>
         <td>View a list of online nicked players</td>
         <td></td>
         <td>STAFF</td>
       </tr>
       <tr>
-        <td>player</td>
+        <td>
+          <label>/player</label>
+        </td>
         <td>pl</td>
         <td>View a list of recent reports for the targeted player</td>
         <td>[player] [page]</td>
         <td>REPORTS</td>
       </tr>
       <tr>
-        <td>profile</td>
+        <td>
+          <label>/profile</label>
+        </td>
         <td>user</td>
         <td>View account info for a player</td>
         <td>[name or uuid]</td>
         <td>LOOKUP_OTHERS</td>
       </tr>
       <tr>
-        <td>punishmenthistory</td>
+        <td>
+          <label>/punishmenthistory</label>
+        </td>
         <td>ph</td>
         <td>View a list of recent punishments</td>
         <td>[page]</td>
         <td>PUNISH</td>
       </tr>
       <tr>
-        <td>queue</td>
-        <td>sponsorqueue sq /sponsor queue</td>
+        <td>
+          <label>/queue</label>
+        </td>
+        <td>sponsorqueue sq [/sponsor queue]</td>
         <td>View the sponsored maps queue</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>record</td>
+        <td>
+          <label>/record</label>
+        </td>
         <td>infractions mypunishments</td>
         <td>View your punishment histpry</td>
         <td>[page]</td>
         <td>LOOKUP</td>
       </tr>
       <tr>
-        <td>repeatpunishment</td>
+        <td>
+          <label>/repeatpunishment</label>
+        </td>
         <td>rp</td>
         <td>Repeat the last punishment you performed for another player</td>
         <td>[player]</td>
         <td>PUNISH</td>
       </tr>
       <tr>
-        <td>report</td>
+        <td>
+          <label>/report</label>
+        </td>
         <td></td>
         <td>Report a player who is breaking the rules</td>
         <td>[username] [reason]</td>
         <td></td>
       </tr>
       <tr>
-        <td>reports</td>
+        <td>
+          <label>/reports</label>
+        </td>
         <td>reporthistory reps</td>
         <td>View report history</td>
         <td></td>
         <td>REPORTS</td>
       </tr>
       <tr>
-        <td>request</td>
+        <td>
+          <label>/request</label>
+        </td>
         <td>req</td>
         <td>Request a map</td>
         <td>[map] – Name of map to request</td>
         <td>REQUEST</td>
       </tr>
       <tr>
-        <td>requests</td>
+        <td>
+          <label>/requests clear</label>
+        </td>
+        <td></td>
+        <td>Clear map requests</td>
+        <td>[map] – Leave emtpy to clear all</td>
+        <td>STAFF</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/requests</label>
+        </td>
         <td>reqs</td>
         <td>View and manage map requests</td>
         <td>clear</td>
         <td>STAFF</td>
       </tr>
       <tr>
-        <td>seen</td>
+        <td>
+          <label>/seen</label>
+        </td>
         <td>lastseen find</td>
         <td>View when a player was last seen online</td>
         <td>[player]</td>
         <td>FIND</td>
       </tr>
       <tr>
-        <td>sponsor</td>
-        <td></td>
-        <td>View the sponsor request menu</td>
-        <td>cancel info</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>sponsor maps</td>
+        <td>
+          <label>/sponsor maps</label>
+        </td>
         <td></td>
         <td>View a list of maps which can be sponsored</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>sponsor request</td>
+        <td>
+          <label>/sponsor request</label>
+        </td>
         <td>submit add</td>
         <td>Sponsor a map request</td>
         <td>[map] – Name of map to sponsor (only allowed maps)</td>
         <td></td>
       </tr>
       <tr>
-        <td>staff</td>
+        <td>
+          <label>/sponsor</label>
+        </td>
+        <td></td>
+        <td>View the sponsor request menu</td>
+        <td>info, cancel – defaults to info</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/staff</label>
+        </td>
         <td>mods admins</td>
         <td>View a list of online staff members</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>sudo</td>
+        <td>
+          <label>/sudo</label>
+        </td>
         <td>force</td>
         <td>Force targets to perform given command</td>
         <td>[commands]</td>
         <td>ADMIN</td>
       </tr>
       <tr>
-        <td>tempban</td>
-        <td>tb</td>
+        <td>
+          <label>/tempban</label>
+        </td>
+        <td>tb [/ban temp temporary t]</td>
         <td>Temporarily bans a player from a server</td>
         <td>[player] [duration] [reason]</td>
+        <td>BAN</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/tokens balance</label>
+        </td>
+        <td></td>
+        <td>Check your token balance</td>
+        <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>tokens</td>
-        <td>sponsortokens token</td>
-        <td>View how many sponsor tokens you have</td>
-        <td>balance</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>tokens give</td>
+        <td>
+          <label>/tokens give</label>
+        </td>
         <td>award</td>
         <td>Give the target player sponsor tokens</td>
         <td>[player] [token amount]</td>
         <td>ADMIN</td>
       </tr>
       <tr>
-        <td>tp</td>
+        <td>
+          <label>/tokens</label>
+        </td>
+        <td>sponsortokens token</td>
+        <td>View how many sponsor tokens you have</td>
+        <td>defaults to balance</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/tp</label>
+        </td>
         <td>teleport</td>
         <td>Teleport to another player</td>
-        <td>[player]</td>
+        <td>[player] [other player]</td>
         <td>TELEPORT</td>
       </tr>
       <tr>
-        <td>tphere</td>
+        <td>
+          <label>/tphere</label>
+        </td>
         <td>bring tph</td>
         <td>Teleport players to you</td>
         <td>[player]</td>
         <td>TELEPORT_OTHERS</td>
       </tr>
       <tr>
-        <td>tplocation</td>
+        <td>
+          <label>/tplocation</label>
+        </td>
         <td>tpl tploc</td>
         <td>Teleport to specific coordinates</td>
-        <td>[x,y,z]</td>
+        <td>[x,y,z] [target player]</td>
         <td>TELEPORT_LOCATION</td>
       </tr>
       <tr>
-        <td>tptarget</td>
+        <td>
+          <label>/tptarget</label>
+        </td>
         <td>tptg tg</td>
         <td>Target a player for the player hook tool</td>
         <td></td>
         <td>STAFF</td>
       </tr>
       <tr>
-        <td>translate</td>
+        <td>
+          <label>/translate</label>
+        </td>
         <td></td>
         <td>Translate the given chat message</td>
         <td></td>
         <td>TRANSLATE</td>
       </tr>
       <tr>
-        <td>unban</td>
+        <td>
+          <label>/unban</label>
+        </td>
         <td>pardon forgive</td>
         <td>Pardon all active punishments for a player</td>
         <td>[player]</td>
         <td>UNBAN</td>
       </tr>
       <tr>
-        <td>unmute</td>
+        <td>
+          <label>/unmute</label>
+        </td>
         <td>um</td>
         <td>Unmute a player</td>
         <td>[player]</td>
         <td>MUTE</td>
       </tr>
       <tr>
-        <td>uptime</td>
+        <td>
+          <label>/uptime</label>
+        </td>
         <td></td>
         <td>View how long the server has been online</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>usernamehistoy</td>
+        <td>
+          <label>/usernamehistoy</label>
+        </td>
         <td>uh</td>
         <td>View the name history of a user</td>
         <td>[player]</td>
         <td>LOOKUP_OTHERS</td>
       </tr>
       <tr>
-        <td>warn</td>
+        <td>
+          <label>/warn</label>
+        </td>
         <td>w</td>
         <td>Warn a player for bad behavior</td>
         <td>[player] [reason]</td>

--- a/docs/commands/events.mdx
+++ b/docs/commands/events.mdx
@@ -1,0 +1,69 @@
+---
+id: events
+title: Events Commands
+---
+
+This page describes a list of commands, aliases and permissions for the Events plugin.
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Commands</th>
+        <th>Description</th>
+        <th>Useage</th>
+        <th>Permissions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>create</td>
+        <td>Creates a tournament</td>
+        <td></td>
+        <td>events.staff</td>
+      </tr>
+      <tr>
+        <td>register</td>
+        <td>Register a team</td>
+        <td>&lt;team&gt;</td>
+        <td>events.staff</td>
+      </tr>
+      <tr>
+        <td>list</td>
+        <td>List all loaded teams</td>
+        <td></td>
+        <td>events.staff</td>
+      </tr>
+      <tr>
+        <td>info</td>
+        <td>View information about a team</td>
+        <td>&lt;team&gt;</td>
+        <td>events.staff</td>
+      </tr>
+      <tr>
+        <td>unregisterall</td>
+        <td>Clear all registered teams</td>
+        <td></td>
+        <td>events.staff</td>
+      </tr>
+      <tr>
+        <td>score</td>
+        <td>Shows the current score in the tournament</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>rounds</td>
+        <td>Shows the rounds from this event</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>veto</td>
+        <td>Veto a map</td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/docs/commands/events.mdx
+++ b/docs/commands/events.mdx
@@ -17,51 +17,67 @@ This page describes a list of commands, aliases and permissions for the Events p
     </thead>
     <tbody>
       <tr>
-        <td>create</td>
+        <td>
+          <label>/create</label>
+        </td>
         <td>Creates a tournament</td>
         <td></td>
         <td>events.staff</td>
       </tr>
       <tr>
-        <td>register</td>
-        <td>Register a team</td>
-        <td>&lt;team&gt;</td>
+        <td>
+          <label>/info</label>
+        </td>
+        <td>View information about a team</td>
+        <td>[team]</td>
         <td>events.staff</td>
       </tr>
       <tr>
-        <td>list</td>
+        <td>
+          <label>/list</label>
+        </td>
         <td>List all loaded teams</td>
         <td></td>
         <td>events.staff</td>
       </tr>
       <tr>
-        <td>info</td>
-        <td>View information about a team</td>
-        <td>&lt;team&gt;</td>
+        <td>
+          <label>/register</label>
+        </td>
+        <td>Register a team</td>
+        <td>[team]</td>
         <td>events.staff</td>
       </tr>
       <tr>
-        <td>unregisterall</td>
-        <td>Clear all registered teams</td>
-        <td></td>
-        <td>events.staff</td>
-      </tr>
-      <tr>
-        <td>score</td>
-        <td>Shows the current score in the tournament</td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>rounds</td>
+        <td>
+          <label>/rounds</label>
+        </td>
         <td>Shows the rounds from this event</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>veto</td>
-        <td>Veto a map</td>
+        <td>
+          <label>/score</label>
+        </td>
+        <td>Shows the current score in the tournament</td>
         <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/unregisterall</label>
+        </td>
+        <td>Clear all registered teams</td>
+        <td></td>
+        <td>events.staff</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/veto</label>
+        </td>
+        <td>Veto a map</td>
+        <td>[number]</td>
         <td></td>
       </tr>
     </tbody>

--- a/docs/commands/main.mdx
+++ b/docs/commands/main.mdx
@@ -1,0 +1,370 @@
+---
+id: main
+title: PGM Commands
+---
+
+This page describes a list of PGM commands, aliases and permissions.
+Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Command</th>
+        <th>Aliases</th>
+        <th>Description</th>
+        <th>Flags</th>
+        <th>Useage</th>
+        <th>Permissions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>alias</td>
+        <td></td>
+        <td>Rename a team</td>
+        <td></td>
+        <td>[old name] [new name]</td>
+        <td>GAMEPLAY</td>
+      </tr>
+      <tr>
+        <td>timelimit</td>
+        <td>tl</td>
+        <td>Start a time limit</td>
+        <td>-r </td>
+        <td>duration [result] [overtime] [max-overtime]</td>
+        <td>GAMEPLAY</td>
+      </tr>
+      <tr>
+        <td>join</td>
+        <td>play</td>
+        <td>Join the match</td>
+        <td>-f force</td>
+        <td>[team] – defaults to random</td>
+        <td>JOIN</td>
+      </tr>
+      <tr>
+        <td>force</td>
+        <td></td>
+        <td>Force a player onto a team</td>
+        <td></td>
+        <td>[player] [team]</td>
+        <td>JOIN_FORCE</td>
+      </tr>
+      <tr>
+        <td>shuffle</td>
+        <td></td>
+        <td>Shuffle players among the teams</td>
+        <td>-a all -f force</td>
+        <td></td>
+        <td>JOIN_FORCE</td>
+      </tr>
+      <tr>
+        <td>pgm</td>
+        <td></td>
+        <td>Reload the config</td>
+        <td></td>
+        <td></td>
+        <td>RELOAD</td>
+      </tr>
+      <tr>
+        <td>loadnewmaps</td>
+        <td>findnewmaps new maps</td>
+        <td>Load New Maps</td>
+        <td></td>
+        <td></td>
+        <td>RELOAD</td>
+      </tr>
+      <tr>
+        <td>min</td>
+        <td></td>
+        <td>Set the min players on a team</td>
+        <td></td>
+        <td>team (reset| min-players)</td>
+        <td>RESIZE</td>
+      </tr>
+      <tr>
+        <td>size</td>
+        <td></td>
+        <td>Set the max players</td>
+        <td></td>
+        <td>reset | max-players [max-overfill]</td>
+        <td>RESIZE</td>
+      </tr>
+      <tr>
+        <td>size</td>
+        <td></td>
+        <td>Set the max players on a team</td>
+        <td></td>
+        <td>team (reset| min-players)</td>
+        <td>RESIZE</td>
+      </tr>
+      <tr>
+        <td>min</td>
+        <td></td>
+        <td>Set the min players on a&nbsp;&nbsp;team</td>
+        <td></td>
+        <td></td>
+        <td>RESIZE</td>
+      </tr>
+      <tr>
+        <td>setnext</td>
+        <td>sn</td>
+        <td>Change the next map</td>
+        <td>-f force -r reset</td>
+        <td></td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>setpool</td>
+        <td>setrot</td>
+        <td>Change the map pool</td>
+        <td>-r reset -t timelimit -m matchlimit</td>
+        <td>[pool name]</td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>skip</td>
+        <td></td>
+        <td>Skip the next map</td>
+        <td></td>
+        <td></td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>add</td>
+        <td></td>
+        <td>Add a custom map to the next vote</td>
+        <td></td>
+        <td></td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>remove</td>
+        <td>rm</td>
+        <td>Remove a custom map from the next vote</td>
+        <td></td>
+        <td></td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>mode</td>
+        <td></td>
+        <td>Toggle the voting mode between replace and override</td>
+        <td></td>
+        <td></td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>clear</td>
+        <td></td>
+        <td>Clear all custom map selections from the next vote</td>
+        <td></td>
+        <td></td>
+        <td>SETNEXT</td>
+      </tr>
+      <tr>
+        <td>cycle</td>
+        <td></td>
+        <td>Cycle to the next match</td>
+        <td>-f force</td>
+        <td></td>
+        <td>START</td>
+      </tr>
+      <tr>
+        <td>recycle</td>
+        <td>rematch</td>
+        <td>Reload (cycle to) the current map</td>
+        <td>-f force</td>
+        <td></td>
+        <td>START</td>
+      </tr>
+      <tr>
+        <td>start</td>
+        <td>begin</td>
+        <td>Start the match</td>
+        <td></td>
+        <td></td>
+        <td>START</td>
+      </tr>
+      <tr>
+        <td>cancel</td>
+        <td>cancelrestart cr</td>
+        <td>Cancels all countdowns</td>
+        <td></td>
+        <td></td>
+        <td>STOP</td>
+      </tr>
+      <tr>
+        <td>finish</td>
+        <td>end</td>
+        <td>End the match</td>
+        <td></td>
+        <td></td>
+        <td>STOP</td>
+      </tr>
+      <tr>
+        <td>restart</td>
+        <td>queuerestart qr</td>
+        <td>Restart the server</td>
+        <td>-f force</td>
+        <td></td>
+        <td>STOP</td>
+      </tr>
+      <tr>
+        <td>class</td>
+        <td>selectclass c cl</td>
+        <td>Selects your class</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>classlist</td>
+        <td>classes listclasses cls</td>
+        <td>List all available classes</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>inventory</td>
+        <td>inv vi</td>
+        <td>View a player’s inventory</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>list</td>
+        <td>who online ls</td>
+        <td>View a list of online players</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>list</td>
+        <td>ls</td>
+        <td>View a list of maps that have been selected for the next vote </td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>map</td>
+        <td>mapinfo</td>
+        <td>Show info about a map</td>
+        <td></td>
+        <td>[map name] – defaults to current map</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>maps </td>
+        <td>maplist ml</td>
+        <td>List all maps loaded</td>
+        <td>-a author -t tag1, tag2, -n name</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>match</td>
+        <td>matchinfo</td>
+        <td>Show the match info</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>mode list</td>
+        <td>mode pages</td>
+        <td>List all objective modes</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>mode next</td>
+        <td></td>
+        <td>Show the next objective mode</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>nextmap</td>
+        <td>mn mapnext nm next</td>
+        <td>Show which map is playing next</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>pool</td>
+        <td>rotation rot</td>
+        <td>List the maps in the map pool</td>
+        <td>-p pool -s scores -c chance of vote</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>pools</td>
+        <td>rotations rots</td>
+        <td>List all the map pools</td>
+        <td>-d dynamic only</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>proximity</td>
+        <td>prox</td>
+        <td>Show the progress of each objective</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>push</td>
+        <td></td>
+        <td>Reschedule an objective mode</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>setting</td>
+        <td></td>
+        <td>Get the value of a setting</td>
+        <td></td>
+        <td>[setting]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>stats</td>
+        <td></td>
+        <td>Show your stats for the match</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>votebook</td>
+        <td></td>
+        <td>Spawn a vote book</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>votenext</td>
+        <td></td>
+        <td>Vote for the next map</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+Tables generated using https://www.tablesgenerator.com/html_tables/

--- a/docs/commands/main.mdx
+++ b/docs/commands/main.mdx
@@ -10,7 +10,7 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
   <table>
     <thead>
       <tr>
-        <th>Command</th>
+        <th>Commands</th>
         <th>Aliases</th>
         <th>Description</th>
         <th>Flags</th>
@@ -20,23 +20,41 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
     </thead>
     <tbody>
       <tr>
-        <td>alias</td>
+        <td>
+          <label>/team alias</label>
+        </td>
         <td></td>
         <td>Rename a team</td>
         <td></td>
-        <td>[old name] [new name]</td>
+        <td>[old team name] [new team name]</td>
         <td>GAMEPLAY</td>
       </tr>
       <tr>
-        <td>timelimit</td>
+        <td>
+          <label>/timelimit</label>
+        </td>
         <td>tl</td>
         <td>Start a time limit</td>
-        <td>-r </td>
-        <td>duration [result] [overtime] [max-overtime]</td>
+        <td>
+          -r result (result can be default, objectives, tie, or name of team)
+        </td>
+        <td>[duration] [result] [overtime] [max-overtime]</td>
         <td>GAMEPLAY</td>
       </tr>
       <tr>
-        <td>join</td>
+        <td>
+          <label>/mode push</label>
+        </td>
+        <td></td>
+        <td>Reschedule all unconditional objective modes</td>
+        <td></td>
+        <td></td>
+        <td>GAMEPLAY</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/join</label>
+        </td>
         <td>play</td>
         <td>Join the match</td>
         <td>-f force</td>
@@ -44,15 +62,19 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>JOIN</td>
       </tr>
       <tr>
-        <td>force</td>
+        <td>
+          <label>/team force</label>
+        </td>
         <td></td>
         <td>Force a player onto a team</td>
         <td></td>
-        <td>[player] [team]</td>
+        <td></td>
         <td>JOIN_FORCE</td>
       </tr>
       <tr>
-        <td>shuffle</td>
+        <td>
+          <label>/team shuffle</label>
+        </td>
         <td></td>
         <td>Shuffle players among the teams</td>
         <td>-a all -f force</td>
@@ -60,7 +82,19 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>JOIN_FORCE</td>
       </tr>
       <tr>
-        <td>pgm</td>
+        <td>
+          <label>/leave</label>
+        </td>
+        <td>obs</td>
+        <td>Leave the match</td>
+        <td></td>
+        <td></td>
+        <td>LEAVE</td>
+      </tr>
+      <tr>
+        <td>
+          <label>/pgm</label>
+        </td>
         <td></td>
         <td>Reload the config</td>
         <td></td>
@@ -68,39 +102,49 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>RELOAD</td>
       </tr>
       <tr>
-        <td>loadnewmaps</td>
+        <td>
+          <label>/loadnewmaps</label>
+        </td>
         <td>findnewmaps new maps</td>
         <td>Load New Maps</td>
-        <td></td>
+        <td>-f force</td>
         <td></td>
         <td>RELOAD</td>
       </tr>
       <tr>
-        <td>min</td>
+        <td>
+          <label>/team min</label>
+        </td>
         <td></td>
         <td>Set the min players on a team</td>
         <td></td>
-        <td>team (reset| min-players)</td>
+        <td>[team] (reset | min-players)</td>
         <td>RESIZE</td>
       </tr>
       <tr>
-        <td>size</td>
+        <td>
+          <label>/team size</label>
+        </td>
         <td></td>
         <td>Set the max players</td>
         <td></td>
-        <td>reset | max-players [max-overfill]</td>
+        <td>[reset] (max-players | max-overfill)</td>
         <td>RESIZE</td>
       </tr>
       <tr>
-        <td>size</td>
+        <td>
+          <label>/ffa size</label>
+        </td>
         <td></td>
         <td>Set the max players on a team</td>
         <td></td>
-        <td>team (reset| min-players)</td>
+        <td>[team] (reset | min-players)</td>
         <td>RESIZE</td>
       </tr>
       <tr>
-        <td>min</td>
+        <td>
+          <label>/ffa min</label>
+        </td>
         <td></td>
         <td>Set the min players on a&nbsp;&nbsp;team</td>
         <td></td>
@@ -108,47 +152,59 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>RESIZE</td>
       </tr>
       <tr>
-        <td>setnext</td>
+        <td>
+          <label>/setnext</label>
+        </td>
         <td>sn</td>
         <td>Change the next map</td>
         <td>-f force -r reset</td>
-        <td></td>
+        <td>[map name]</td>
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>setpool</td>
+        <td>
+          <label>/setpool</label>
+        </td>
         <td>setrot</td>
         <td>Change the map pool</td>
-        <td>-r reset -t timelimit -m matchlimit</td>
+        <td>-r revert to dynamic -t timelimit -m matchlimit</td>
         <td>[pool name]</td>
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>skip</td>
+        <td>
+          <label>/skip</label>
+        </td>
         <td></td>
         <td>Skip the next map</td>
         <td></td>
-        <td></td>
+        <td>[positions]</td>
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>add</td>
+        <td>
+          <label>/vote add</label>
+        </td>
         <td></td>
         <td>Add a custom map to the next vote</td>
         <td></td>
-        <td></td>
+        <td>[map name]</td>
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>remove</td>
+        <td>
+          <label>/vote remove</label>
+        </td>
         <td>rm</td>
         <td>Remove a custom map from the next vote</td>
         <td></td>
-        <td></td>
+        <td>[map name]</td>
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>mode</td>
+        <td>
+          <label>/vote mode</label>
+        </td>
         <td></td>
         <td>Toggle the voting mode between replace and override</td>
         <td></td>
@@ -156,7 +212,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>clear</td>
+        <td>
+          <label>/vote clear</label>
+        </td>
         <td></td>
         <td>Clear all custom map selections from the next vote</td>
         <td></td>
@@ -164,7 +222,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>SETNEXT</td>
       </tr>
       <tr>
-        <td>cycle</td>
+        <td>
+          <label>/cycle</label>
+        </td>
         <td></td>
         <td>Cycle to the next match</td>
         <td>-f force</td>
@@ -172,7 +232,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>START</td>
       </tr>
       <tr>
-        <td>recycle</td>
+        <td>
+          <label>/recycle</label>
+        </td>
         <td>rematch</td>
         <td>Reload (cycle to) the current map</td>
         <td>-f force</td>
@@ -180,7 +242,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>START</td>
       </tr>
       <tr>
-        <td>start</td>
+        <td>
+          <label>/start</label>
+        </td>
         <td>begin</td>
         <td>Start the match</td>
         <td></td>
@@ -188,7 +252,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>START</td>
       </tr>
       <tr>
-        <td>cancel</td>
+        <td>
+          <label>/cancel</label>
+        </td>
         <td>cancelrestart cr</td>
         <td>Cancels all countdowns</td>
         <td></td>
@@ -196,15 +262,19 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>STOP</td>
       </tr>
       <tr>
-        <td>finish</td>
+        <td>
+          <label>/finish</label>
+        </td>
         <td>end</td>
         <td>End the match</td>
         <td></td>
-        <td></td>
+        <td>[competitor]</td>
         <td>STOP</td>
       </tr>
       <tr>
-        <td>restart</td>
+        <td>
+          <label>/restart</label>
+        </td>
         <td>queuerestart qr</td>
         <td>Restart the server</td>
         <td>-f force</td>
@@ -212,7 +282,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>STOP</td>
       </tr>
       <tr>
-        <td>class</td>
+        <td>
+          <label>/class</label>
+        </td>
         <td>selectclass c cl</td>
         <td>Selects your class</td>
         <td></td>
@@ -220,7 +292,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>classlist</td>
+        <td>
+          <label>/classlist</label>
+        </td>
         <td>classes listclasses cls</td>
         <td>List all available classes</td>
         <td></td>
@@ -228,7 +302,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>inventory</td>
+        <td>
+          <label>/inventory</label>
+        </td>
         <td>inv vi</td>
         <td>View a player’s inventory</td>
         <td></td>
@@ -236,7 +312,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>list</td>
+        <td>
+          <label>/list</label>
+        </td>
         <td>who online ls</td>
         <td>View a list of online players</td>
         <td></td>
@@ -244,15 +322,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>list</td>
-        <td>ls</td>
-        <td>View a list of maps that have been selected for the next vote </td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>map</td>
+        <td>
+          <label>/map</label>
+        </td>
         <td>mapinfo</td>
         <td>Show info about a map</td>
         <td></td>
@@ -260,15 +332,19 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>maps </td>
+        <td>
+          <label>/maps</label>
+        </td>
         <td>maplist ml</td>
         <td>List all maps loaded</td>
-        <td>-a author -t tag1, tag2, -n name</td>
+        <td>-a author -t tag1,tag2, -n name</td>
         <td></td>
         <td></td>
       </tr>
       <tr>
-        <td>match</td>
+        <td>
+          <label>/match</label>
+        </td>
         <td>matchinfo</td>
         <td>Show the match info</td>
         <td></td>
@@ -276,15 +352,19 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>mode list</td>
-        <td>mode pages</td>
+        <td>
+          <label>/mode list</label>
+        </td>
+        <td>page</td>
         <td>List all objective modes</td>
         <td></td>
-        <td></td>
+        <td>[page]</td>
         <td></td>
       </tr>
       <tr>
-        <td>mode next</td>
+        <td>
+          <label>/mode next</label>
+        </td>
         <td></td>
         <td>Show the next objective mode</td>
         <td></td>
@@ -292,7 +372,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>nextmap</td>
+        <td>
+          <label>/nextmap</label>
+        </td>
         <td>mn mapnext nm next</td>
         <td>Show which map is playing next</td>
         <td></td>
@@ -300,7 +382,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>pool</td>
+        <td>
+          <label>/pool</label>
+        </td>
         <td>rotation rot</td>
         <td>List the maps in the map pool</td>
         <td>-p pool -s scores -c chance of vote</td>
@@ -308,7 +392,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>pools</td>
+        <td>
+          <label>/pools</label>
+        </td>
         <td>rotations rots</td>
         <td>List all the map pools</td>
         <td>-d dynamic only</td>
@@ -316,7 +402,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>proximity</td>
+        <td>
+          <label>/proximity</label>
+        </td>
         <td>prox</td>
         <td>Show the progress of each objective</td>
         <td></td>
@@ -324,15 +412,9 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>push</td>
-        <td></td>
-        <td>Reschedule an objective mode</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>setting</td>
+        <td>
+          <label>/setting</label>
+        </td>
         <td></td>
         <td>Get the value of a setting</td>
         <td></td>
@@ -340,7 +422,19 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>stats</td>
+        <td>
+          <label>/settings</label>
+        </td>
+        <td></td>
+        <td>Open the settings Menu</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/stats</label>
+        </td>
         <td></td>
         <td>Show your stats for the match</td>
         <td></td>
@@ -348,7 +442,39 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>votebook</td>
+        <td>
+          <label>/toggle</label>
+        </td>
+        <td>set</td>
+        <td>Toggle or set the value of a setting</td>
+        <td></td>
+        <td>[setting] [option]</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/tools</label>
+        </td>
+        <td>observertools ot</td>
+        <td>Open the observer tools menu</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/vote list</label>
+        </td>
+        <td>ls</td>
+        <td>View a list of maps that have been selected for the next vote</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/votebook</label>
+        </td>
         <td></td>
         <td>Spawn a vote book</td>
         <td></td>
@@ -356,15 +482,15 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
       </tr>
       <tr>
-        <td>votenext</td>
+        <td>
+          <label>/votenext</label>
+        </td>
         <td></td>
         <td>Vote for the next map</td>
-        <td></td>
-        <td></td>
+        <td>-o force open</td>
+        <td>[map name]</td>
         <td></td>
       </tr>
     </tbody>
   </table>
 </div>
-
-Tables generated using https://www.tablesgenerator.com/html_tables/

--- a/docs/commands/main.mdx
+++ b/docs/commands/main.mdx
@@ -4,7 +4,7 @@ title: PGM Commands
 ---
 
 This page describes a list of PGM commands, aliases and permissions.
-Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
+Permissions are prefixed with `Permissions` (ie `Permissions.ADMINCHAT`).
 
 <div className="table-container">
   <table>
@@ -19,6 +19,16 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td>
+          <label>/a</label>
+        </td>
+        <td>$ - (do not use forward slash)</td>
+        <td>Send a message to operators</td>
+        <td></td>
+        <td>[message]</td>
+        <td>ADMINCHAT</td>
+      </tr>
       <tr>
         <td>
           <label>/team alias</label>
@@ -146,7 +156,7 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
           <label>/ffa min</label>
         </td>
         <td></td>
-        <td>Set the min players on a&nbsp;&nbsp;team</td>
+        <td>Set the min players on a team</td>
         <td></td>
         <td></td>
         <td>RESIZE</td>
@@ -283,6 +293,16 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
       </tr>
       <tr>
         <td>
+          <label>/vanish</label>
+        </td>
+        <td>v</td>
+        <td>Toggle vanish status</td>
+        <td></td>
+        <td></td>
+        <td>VANISH</td>
+      </tr>
+      <tr>
+        <td>
           <label>/class</label>
         </td>
         <td>selectclass c cl</td>
@@ -299,6 +319,16 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td>List all available classes</td>
         <td></td>
         <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/g</label>
+        </td>
+        <td>all (! - do not use forward slash)</td>
+        <td>Send a message to everyone</td>
+        <td></td>
+        <td>[message]</td>
         <td></td>
       </tr>
       <tr>
@@ -440,6 +470,16 @@ Permissions are prefixed with `Permissions` (ie `Permissions.GAMEPLAY`).
         <td></td>
         <td></td>
         <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>/t</label>
+        </td>
+        <td></td>
+        <td>Send a message to your team</td>
+        <td></td>
+        <td>[message]</td>
+        <td>SETNEXT</td>
       </tr>
       <tr>
         <td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,6 +37,11 @@ module.exports = {
           ],
         },
         {
+          to: "docs/commands/main",
+          label: "Commands",
+          position: "left",
+        },
+        {
           to: "docs/events/main",
           label: "Events",
           position: "left",

--- a/sidebars.js
+++ b/sidebars.js
@@ -83,6 +83,7 @@ module.exports = {
       "guides/packaging/compiling-and-releasing",
     ],
   },
+  Commands: ["commands/main", "commands/community", "commands/events"],
   Events: [
     "events/main",
     {


### PR DESCRIPTION
This PR adds a list of commands for PGM, Community and Events plugins for players and administrators unfamiliar with the commands. There may be some missing details or other advice needed which was why I made a PR for this issue. Also I will have to insert these commands with `<lablel>` and maybe the forward slashes later on. Partially fixes #2 

Use this [table generator](https://www.tablesgenerator.com/html_tables#) website for generating HTML tables.
[Spreadsheet I made for storing this](https://github.com/PGMDev/Website/files/7326011/pgmcommands.ods).