### PR TITLE
Update map.png specification and example image

### DIFF
--- a/docs/guides/packaging/compiling-and-releasing.mdx
+++ b/docs/guides/packaging/compiling-and-releasing.mdx
@@ -27,19 +27,20 @@ Take note of the following coding guidelines when creating your `map.xml` file:
 The `map.png` file displays the image of your map.
 The standard resolution for these pictures is `290x246`.
 This image should contain a general overview of the map's playing area.
+You should use the default resource pack without shaders.
 
 _Image Example_
 
 <div className="row">
   <div className="col col--6">
-    <img src="https://i.imgur.com/7BrMIPA.png" />
+    <img src="https://i.imgur.com/yvUJNu1.png" />
   </div>
   <div className="col">
     <img src="https://i.imgur.com/On5orcO.png" />
   </div>
 </div>
 
-_Source: [BlockBlock](https://github.com/MCResourcePile/overcast-maps/tree/master/maps/blockblock) by Lyzak (left) and [Rage Quit](https://github.com/MCResourcePile/overcast-maps/tree/master/maps/rage_quit) by Plastix & McYukon (right)_
+_Source: [Totally War II](https://github.com/MCResourcePile/overcast-maps/tree/master/maps/totally_war_ii) by Lyzak (left) and [Rage Quit](https://github.com/MCResourcePile/overcast-maps/tree/master/maps/rage_quit) by Plastix & McYukon (right)_
 
 #### Compressing the folder to a ZIP file
 


### PR DESCRIPTION
Adds extra info about not using a custom resource pack or shaders which is pretty standard across 99% of maps.

Also removes example of BlockBlock which had both shaders (a lens flair image?) and a resource pack.