### PR TITLE
Fix precedence typo

### DIFF
--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -240,7 +240,7 @@ Other uses of control points include unlocking an area of the map using objectiv
           The rate for a control point to decay from captured to neutral.
           Applies when nobody is dominating the point.
           <br />
-          <i>Takes presecense over `decay-rate`.</i>
+          <i>Takes precedence over `decay-rate`.</i>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>


### PR DESCRIPTION
This fixes a small typo in the control point documentation.