### PR TITLE
Fix the team attribute of objective filters

### DIFF
--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -1008,9 +1008,9 @@ This filter is a [Dynamic Filter](#dynamic-filters).
         </td>
         <td>Matches if a certain team completed the objective.</td>
         <td>
-          <span className="badge badge--primary">true/false</span>
+          <a href="/docs/modules/format/teams">Team ID</a>
         </td>
-        <td>false</td>
+        <td></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Previously it said the team attribute was a boolean, but according to the example it should be a team ID. This fixes that.