### PR TITLE
Add contested-rate documentation

### DIFF
--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -234,6 +234,21 @@ Other uses of control points include unlocking an area of the map using objectiv
       </tr>
       <tr>
         <td>
+          <label>contested-rate</label>
+        </td>
+        <td>
+          The rate for a control point to decay to its current state. Applies
+          when the point is contested.
+        </td>
+        <td>
+          <span className="badge badge--primary">Number</span>
+        </td>
+        <td colspan="2">
+          <label>decay-rate</label>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label>owned-decay-rate</label>
         </td>
         <td>
@@ -320,8 +335,7 @@ Other uses of control points include unlocking an area of the map using objectiv
           <label>show-info</label>
         </td>
         <td>
-          Display the control point under commands such as <label>/match</label>
-          .
+          Display the control point under commands such as <label>/match</label>.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>


### PR DESCRIPTION
This adds documentation for the addition of `contested-rate` to control points from the pull request here:
https://github.com/PGMDev/PGM/pull/1023

This shouldn't be merged until that PR is.