### PR TITLE
Document map protocol versions (v2)

### DIFF
--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -5,7 +5,7 @@ title: Main Map Element
 
 Every map XML file must contain the base `<map>` module. It contains modules that specify the map name, version, objective, authors, contributors and all other map settings. The objective is the text that players see when they join the match, and so it's important for this to be very clear, concise, and informative.
 
-The `proto=""` attribute specifies what PGM version the XML file was created for. If this value is higher than the version of PGM that is running, the map won't load. If it's lower, the map will load but the XML may be interpreted in an outdated way. Mapmakers should always use the latest supported XML version, and this may be required of new maps that are to be added to any map compilation projects, such as [ResourcePile](https://mcresourcepile.github.io).
+The `proto=""` attribute specifies what PGM version the XML file was created for. Mapmakers should always use the latest supported proto version, which is documented in depth at [Protocol Versions](docs/modules/general/proto).
 
 The maps version should follow the versioning schema `major.minor.patch`.
 
@@ -53,10 +53,10 @@ The maps version should follow the versioning schema `major.minor.patch`.
         </td>
         <td>
           <span className="badge badge--danger">Required</span>
-          The maps XML protocol version.
+          The map's XML protocol version.
         </td>
         <td>
-          <label>1.4.0</label>
+          <label>1.4.2</label>
         </td>
         <td />
       </tr>
@@ -124,7 +124,7 @@ The maps version should follow the versioning schema `major.minor.patch`.
         </td>
         <td>
           <span className="badge badge--danger">Required</span>
-          The map's <a href="http://semver.org">semantic version</a> string.
+          The map's <a href="https://semver.org">semantic version</a> string.
         </td>
         <td>
           <label>1.0.0</label>

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -97,7 +97,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
           <br />
           Disallows <label>&lt;time&gt;</label> inside{" "}
           <label>&lt;score&gt;</label> or <label>&lt;blitz&gt;</label> &
-          disallow <label>&lt;title&gt;</label> inside{" "}
+          disallows <label>&lt;title&gt;</label> inside{" "}
           <label>&lt;blitz&gt;</label>.
           <br />
           Required objectives.

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -6,7 +6,9 @@ title: Protocol Versions
 The `proto=""` attribute specifies what iteration of PGM a certain XML document was created for. It also instructs PGM on whether to allow the usage of deprecated or newly introduced features within a map. If the value is lower than the currently recommended proto version, the map will load but the XML may be interpreted in an outdated way.
 
 Mapmakers should always use the latest supported proto version, and this may be required of new maps that are to be added to any map compilation projects, such as [ResourcePile](https://mcresourcepile.github.io).
+
 #### Map Element
+
 <div className="table-container">
   <table>
     <thead>
@@ -93,7 +95,8 @@ Mapmakers should always use the latest supported proto version, and this may be 
           <label>1.4.0</label>
         </td>
         <td>
-          Filters, regions, and teams are always referenced by its ID.
+          Filters, regions, and teams are always referenced by its ID (replaces{" "}
+          <label>name</label>).
           <br />
           Disallows <label>&lt;time&gt;</label> inside{" "}
           <label>&lt;score&gt;</label> or <label>&lt;blitz&gt;</label> &

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -100,7 +100,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
           disallows <label>&lt;title&gt;</label> inside{" "}
           <label>&lt;blitz&gt;</label>.
           <br />
-          Required objectives.
+          Required objectives to define if they are needed to win the match.
         </td>
       </tr>
       <tr>
@@ -123,7 +123,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
         <td>
           <label>1.3.4</label>
         </td>
-        <td>Wools have a location property.</td>
+        <td>Wools must have a location property.</td>
       </tr>
       <tr>
         <td>
@@ -206,7 +206,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
 
 - Filters, regions, and kits now use `id` instead of `name`.
   - Keep in mind that IDs are all in the same namespace, so you can not use the same ID for two different types of thing.
-- Teams have a `id` attribute and are always referenced by it everywhere in the XML, **never** by name.
+- Teams have an `id` attribute and are always referenced by it everywhere in the XML, **never** by name.
 - Standalone filter definitions are no longer wrapped in a `<filter>` tag, they start with an actual filter, just like regions, e.g.
 
   - ```xml
@@ -222,7 +222,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
   - All of the new built-ins have equivalent tags of the same name i.e. `<always/>` & `<never/>`.
 - Filters can no longer have parents.
 - `<allow`> and `<deny>` can now be used anywhere a filter is expected, and actually function how they were supposed to i.e. they cause the filter to be ignored (skipped over) if it does not match.
-- Blitz or Ghost Squadron titles are no longer a part of the [Blitz module](/docs/modules/objectives/blitz), instead they are set as a attribute of the `<map>` element and can be used with any gamemode.
+- Blitz titles are no longer a part of the [Blitz Module](/docs/modules/objectives/blitz), instead they are set using the map sub-element `<game>` and can be used with any gamemode.
 - Match time limit is no longer part of the `<score>` or `<blitz>` module, instead it is defined directly in the root element.
 
   - ```xml

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -77,7 +77,6 @@ Mapmakers should always use the latest supported proto version, and this may be 
           <label>1.4.2</label>
         </td>
         <td>
-          <span className="badge badge--warning">Forward Compatibility</span>
           Refer to <a href="#changes-in-142">Changes in 1.4.2</a>.
         </td>
       </tr>
@@ -86,8 +85,10 @@ Mapmakers should always use the latest supported proto version, and this may be 
           <label>1.4.1</label>
         </td>
         <td>
-          <span className="badge badge--warning">Forward Compatibility</span>
-          Refer to <a href="#changes-in-141">Changes in 1.4.1</a>.
+          <span className="badge badge--secondary">Note</span>
+          No change in features on PGM. Use <label>1.4.0</label> or <label>
+            1.4.2
+          </label> instead.
         </td>
       </tr>
       <tr>
@@ -120,7 +121,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
         <td>
           <label>1.3.5</label>
         </td>
-        <td>Filters is aware of who owns TNT.</td>
+        <td>Filters are aware of who owns TNT.</td>
       </tr>
       <tr>
         <td>
@@ -174,32 +175,8 @@ Mapmakers should always use the latest supported proto version, and this may be 
 - Added a `<grounded/>` filter to check if the player is standing on the ground.
 - Added `<match-started/>`, `<match-running/>` & `<match-finished/>` filters that are used to check the state of the current match.
 - New `pre-match-physics` attribute for the terrain module to enable physics events before the match starts.
-
-### Changes in 1.4.1
-
-<span className="badge badge--danger">Breaking</span>
-<br />
-
-<span className="badge badge--secondary">Not implemented</span>
-
-- `<random>` filters now only respond to instantaneous events, and abstain when used in any persistent context. This breaks some uses that relied on undefined behavior, but these would likely break anyway as filters gain more dynamic functionality.
-  ***
-
-<span class="badge badge--primary">Change</span>
-<br />
-
-- <span className="badge badge--secondary">Not implemented</span> As of Minecraft
-  1.9, TNT fuse time is no longer limited to 4 seconds.
-- Portals react to player move events allowing almost instant teleportation as soon as the filter matches.
-  ***
-
-<span class="badge badge--success">New</span>
-<br />
-
 - Added `<observing>` and `<participant>` filters. Also added an `observers` filter property to portals to restrict observer access.
 - Added player rank and score filters. Filters return if the player's rank or score is within the specified range.
-- <span className="badge badge--secondary">Not implemented</span> Added a gliding
-  filter, returns if the player is gliding with an elytra.
 - Control points have new `recovery` and `decay` attributes that replace the `incremental` attribute and allow more control of the progress.
 
 ### Changes in 1.4.0
@@ -223,8 +200,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
 - There is no longer a filter type called `<block>`, use `<material>` instead. `<block>` is always interpreted as a region.
 - The old built-in filters are gone, and there are only two new ones: `always` which is equivalent to `allow-all`, and never which is equivalent to `deny-all`.
   - All of the new built-ins have equivalent tags of the same name i.e. `<always/>` & `<never/>`.
-- Filters can no longer have parents.
-- `<allow`> and `<deny>` can now be used anywhere a filter is expected, and actually function how they were supposed to i.e. they cause the filter to be ignored (skipped over) if it does not match.
+- `<allow>` and `<deny>` can now be used anywhere a filter is expected, and actually function how they were supposed to i.e. they cause the filter to be ignored (skipped over) if it does not match.
 - Blitz titles are no longer a part of the [Blitz Module](/docs/modules/objectives/blitz), instead they are set using the map sub-element `<game>` and can be used with any gamemode.
 - Match time limit is no longer part of the `<score>` or `<blitz>` module, instead it is defined directly in the root element.
 
@@ -269,37 +245,10 @@ Mapmakers should always use the latest supported proto version, and this may be 
 <span className="badge badge--success">New</span>
 <br />
 
-- There is a new half-space region type that contains everything on one side of an arbitrary plane. The plane is defined by an origin point and a normal vector, and the region contains everything on the side of the plane that the normal is pointing towards. The example below defines a region with a diagonal boundary:
-
-  - ```xml
-    <half origin="5,0,0" normal="1,1,0"/>
-    ```
-
-- Two new region types `<above>` and `<below>` can be used to conveniently define axis-aligned half-spaces:
-
-  - ```xml
-    <above y="50"/>      <!-- everything above Y=50 -->
-    <below x="0" z="0"/> <!-- everything in the -X, -Z quadrant -->
-    ```
-
 - There are two built-in regions called `everywhere` and `nowhere` that contain all points and no points, respectively.
   - All of the new built-ins have equivalent tags of the same name i.e. `<everywhere/>` & `<nowhere/>`.
 - A team can have a minimum required size with the `min=""` attribute.
 - Objectives have a `required` attribute that specifies if they are required to complete the match.
-- A players gamemode can be changed by using the new `<game-mode> </game-mode>` kit.
-- New [world border module](/docs/modules/environment/border) that can be used to create a shifting and/or auto resizing world border.
-- Support added for block punch and trample `<block-drops>`.
-- Custom item [crafting recipe module](/docs/modules/gear/crafting).
-- All items of a specific type can be modified for the whole match using the [`<item-mods>` module](/docs/modules/gear/item-mods).
-- Teamless gamemodes with the [`<players/>` module](/docs/modules/format/players).
-- Heads can be given to players in kits with the [`<head>` element](/docs/modules/gear/items/#custom-heads).
-- Cause filters have several new possible values they can filter for.
-- Added the [`<relation>` filter](/docs/modules/mechanics/filters/#player-relation-filters) to check the relation between two players.
-- The world generator can be modified with the [terrain module](/docs/modules/environment/world#terrain). This module allows the seed, void/vanilla generator, and world folder location to be specified.
-- XML files can now contain conditional `<if>` and `<unless>` statements. These statements allow modules to be loaded on specific servers or during holiday events.
-- The maps display gamemode can be specified with the `<gamemode>` element.
-- Added a [shield kit module](/docs/modules/gear/kits/#shield-kit-removable) that gives a player an absorption hearts recharging shield.
-- [Pickups module](/docs/modules/gear/pickups) for location specific kit pickups.
   ***
 
 <span className="badge badge--info">Removed</span>
@@ -322,7 +271,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
     </core>
     <core region="my-region"/>
     ```
-  - Similarly spawn regions must be defined in a `<regions>` sub-element or referenced in a `regions` attribute.
+  - Similarly, spawn regions must be defined in a `<regions>` sub-element or referenced in a `regions` attribute.
   - ```xml
     <spawns>
         <spawn team="red">
@@ -335,4 +284,3 @@ Mapmakers should always use the latest supported proto version, and this may be 
     ```
 
 - Everything scores 0 points by default, this means you have to explicitly define `<kills>` and `<deaths>` in the score module if you want players to get points for killing players.
-- The `<playable>` region module has been removed, this should now be handled using filters.

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -6,7 +6,7 @@ title: Protocol Versions
 The `proto=""` attribute specifies what iteration of PGM a certain XML document was created for. It also instructs PGM on whether to allow the usage of deprecated or newly introduced features within a map. If the value is lower than the currently recommended proto version, the map will load but the XML may be interpreted in an outdated way.
 
 Mapmakers should always use the latest supported proto version, and this may be required of new maps that are to be added to any map compilation projects, such as [ResourcePile](https://mcresourcepile.github.io).
-
+#### Map Element
 <div className="table-container">
   <table>
     <thead>

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -1,0 +1,335 @@
+---
+id: proto
+title: Protocol Versions
+---
+
+The `proto=""` attribute specifies what iteration of PGM a certain XML document was created for. It also instructs PGM on whether to allow the usage of deprecated or newly introduced features within a map. If the value is lower than the currently recommended proto version, the map will load but the XML may be interpreted in an outdated way.
+
+Mapmakers should always use the latest supported proto version, and this may be required of new maps that are to be added to any map compilation projects, such as [ResourcePile](https://mcresourcepile.github.io).
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Map Element</th>
+        <th>Description</th>
+        <th>Value/Children</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>{`<map> </map>`}</label>
+        </td>
+        <td>The main map node containing the protocol version to be used.</td>
+        <td>
+          <span className="badge badge--secondary">XML Modules</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+##### Map Attributes
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Description</th>
+        <th>Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>proto</label>
+        </td>
+        <td>
+          <span className="badge badge--danger">Required</span>
+          The map XML's protocol version.
+        </td>
+        <td>
+          <span className="badge badge--success">Recommended</span>
+          <label>1.4.2</label>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+##### Map Protocol Values
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Version</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>1.4.2</label>
+        </td>
+        <td>
+          <span className="badge badge--warning">Forward Compatibility</span>
+          Refer to <a href="#changes-in-142">Changes in 1.4.2</a>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.4.1</label>
+        </td>
+        <td>
+          <span className="badge badge--warning">Forward Compatibility</span>
+          Refer to <a href="#changes-in-141">Changes in 1.4.1</a>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.4.0</label>
+        </td>
+        <td>
+          Filters, regions, and teams are always referenced by its ID.
+          <br />
+          Disallowed <label>&lt;time&gt;</label> inside{" "}
+          <label>&lt;score&gt;</label> or <label>&lt;blitz&gt;</label> &
+          disallow <label>&lt;title&gt;</label> inside{" "}
+          <label>&lt;blitz&gt;</label>.
+          <br />
+          Required objectives.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.3.6</label>
+        </td>
+        <td>
+          Moved all defining elements out of module XML root.
+          <br />
+          Everything scores zero points by default.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.3.5</label>
+        </td>
+        <td>Filters is aware of who owns TNT.</td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.3.4</label>
+        </td>
+        <td>Wools have a location property.</td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.3.3</label>
+        </td>
+        <td>Define how overlapping regions should behave.</td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.3.2</label>
+        </td>
+        <td>Added monument modes.</td>
+      </tr>
+      <tr>
+        <td>
+          <label>1.3.1</label>
+        </td>
+        <td>Off-by-one region bug fixed.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Map Protocol Changelog
+
+### Changes in 1.4.2
+
+<span className="badge badge--danger">Breaking</span>
+<br />
+
+- The objectives filter will now always automatically derive team ownership for the objective from context. To match an objective without any specific team, the <label>any="true"</label> attribute needs to be specified.
+  ***
+
+<span class="badge badge--success">New</span>
+<br />
+
+<span className="badge badge--secondary">Partially implemented</span>{" "}
+
+- Portals, kits, score boxes & structures can now be dynamically applied using dynamic filters. All region types are dynamic, however, only some filter types are dynamic.
+  - Kits now have [`give`, `take` & `lend` properties](/docs/modules/gear/kits#dynamic-kits).
+  - Portals have [`forward`, `reverse` & `transit` properties](/docs/modules/mechanics/portals#portal-sub-elements).
+  - Structures & [score boxes](/docs/modules/objectives/scoring#score-box-attributes) have a `trigger` property.
+- <span className="badge badge--secondary">Not implemented</span> Added a player
+  count filter.
+- Added a `<grounded/>` filter to check if the player is standing on the ground.
+- Added `<match-started/>`, `<match-running/>` & `<match-finished/>` filters that are used to check the state of the current match.
+- New `pre-match-physics` attribute for the terrain module to enable physics events before the match starts.
+
+### Changes in 1.4.1
+
+<span className="badge badge--danger">Breaking</span>
+<br />
+
+<span className="badge badge--secondary">Not implemented</span>
+
+- `<random>` filters now only respond to instantaneous events, and abstain when used in any persistent context. This breaks some uses that relied on undefined behavior, but these would likely break anyway as filters gain more dynamic functionality.
+  ***
+
+<span class="badge badge--primary">Change</span>
+<br />
+
+- <span className="badge badge--secondary">Not implemented</span> As of Minecraft
+  1.9, TNT fuse time is no longer limited to 4 seconds.
+- Portals react to player move events allowing almost instant teleportation as soon as the filter matches.
+  ***
+
+<span class="badge badge--success">New</span>
+<br />
+
+- Added `<observing>` and `<participant>` filters. Also added an `observers` filter property to portals to restrict observer access.
+- Added player rank and score filters. Filters return if the player's rank or score is within the specified range.
+- <span className="badge badge--secondary">Not implemented</span> Added a gliding
+  filter, returns if the player is gliding with an elytra.
+- Control points have new `recovery` and `decay` attributes that replace the `incremental` attribute and allow more control of the progress.
+
+### Changes in 1.4.0
+
+<span className="badge badge--danger">Breaking</span>
+<br />
+
+- Filters, regions, and kits now use `id` instead of `name`.
+  - Keep in mind that IDs are all in the same namespace, so you can not use the same ID for two different types of thing.
+- Teams have a `id` attribute and are always referenced by it everywhere in the XML, **never** by name.
+- Standalone filter definitions are no longer wrapped in a `<filter>` tag, they start with an actual filter, just like regions, e.g.
+
+  - ```xml
+    <filters>
+      <team id="only-red">red-team</team>
+    </filters>
+    ```
+
+- The region for an `<apply>` must be either a `region` attribute or a `<region>` sub-element. It cannot appear directly inside the `<apply>` tag.
+- Inline filters must always be a single tag, multiple tags are not accepted anywhere. To combine multiple filters, always use a compound filter like `<all>` or `<any>`. This change is retroactive, and affects _all_ proto versions.
+- There is no longer a filter type called `<block>`, use `<material>` instead. `<block>` is always interpreted as a region.
+- The old built-in filters are gone, and there are only two new ones: `always` which is equivalent to `allow-all`, and never which is equivalent to `deny-all`.
+  - All of the new built-ins have equivalent tags of the same name i.e. `<always/>` & `<never/>`.
+- Filters can no longer have parents.
+- `<allow`> and `<deny>` can now be used anywhere a filter is expected, and actually function how they were supposed to i.e. they cause the filter to be ignored (skipped over) if it does not match.
+- Blitz or Ghost Squadron titles are no longer a part of the [Blitz module](/docs/modules/objectives/blitz), instead they are set as a attribute of the `<map>` element and can be used with any gamemode.
+- Match time limit is no longer part of the `<score>` or `<blitz>` module, instead it is defined directly in the root element.
+
+  - ```xml
+    <map proto="1.4.0">
+    <time result="objectives">5m</time>
+    <!-- Other modules. -->
+    </map>
+    ```
+
+  ***
+
+  <span class="badge badge--primary">Change</span>
+  <br />
+
+- The top-level tags `<filters>` and `<regions>` are now the same thing. You can define filters, regions, and `<apply>`s in either one (remember that regions are a type of filter, have been for a while now).
+- Any filter tag anywhere can have an `id` attribute.
+- The `<apply>` tag accepts both references and inline definitions for its `region`, `kit`, and all of its filter properties, e.g. the two tags below are equivalent:
+
+  - ```xml
+    <apply region="effect-pad" kit="effect-kit" filter="only-red" block="only-leaves" />
+    <apply>
+        <region>
+            <cuboid min="1,2,3" max="4,5,6"/> <!-- effect-pad -->
+        </region>
+        <kit>
+            <potion>...</potion> <!-- effect-kit -->
+        </kit>
+        <filter>
+            <team>red-team</team>
+        </filter>
+        <block>
+            <material>leaves</material>
+        </block>
+    </apply>
+    ```
+
+- The `safe` and `spread` attributes of spawns can now be combined.
+- A items slot attribute is no longer required in kits. This attribute now also accepts Mojang slot names e.g. `slot.hotbar.8` or `armor.head`.
+  ***
+
+<span className="badge badge--success">New</span>
+<br />
+
+- There is a new half-space region type that contains everything on one side of an arbitrary plane. The plane is defined by an origin point and a normal vector, and the region contains everything on the side of the plane that the normal is pointing towards. The example below defines a region with a diagonal boundary:
+
+  - ```xml
+    <half origin="5,0,0" normal="1,1,0"/>
+    ```
+
+- Two new region types `<above>` and `<below>` can be used to conveniently define axis-aligned half-spaces:
+
+  - ```xml
+    <above y="50"/>      <!-- everything above Y=50 -->
+    <below x="0" z="0"/> <!-- everything in the -X, -Z quadrant -->
+    ```
+
+- There are two built-in regions called `everywhere` and `nowhere` that contain all points and no points, respectively.
+  - All of the new built-ins have equivalent tags of the same name i.e. `<everywhere/>` & `<nowhere/>`.
+- A team can have a minimum required size with the `min=""` attribute.
+- Objectives have a `required` attribute that specifies if they are required to complete the match.
+- A players gamemode can be changed by using the new `<game-mode> </game-mode>` kit.
+- New [world border module](/docs/modules/environment/border) that can be used to create a shifting and/or auto resizing world border.
+- Support added for block punch and trample `<block-drops>`.
+- Custom item [crafting recipe module](/docs/modules/gear/crafting).
+- All items of a specific type can be modified for the whole match using the [`<item-mods>` module](/docs/modules/gear/item-mods).
+- Teamless gamemodes with the [`<players/>` module](/docs/modules/format/players).
+- Heads can be given to players in kits with the [`<head>` element](/docs/modules/gear/items/#custom-heads).
+- Cause filters have several new possible values they can filter for.
+- Added the [`<relation>` filter](/docs/modules/mechanics/filters/#player-relation-filters) to check the relation between two players.
+- The world generator can be modified with the [terrain module](/docs/modules/environment/world#terrain). This module allows the seed, void/vanilla generator, and world folder location to be specified.
+- XML files can now contain conditional `<if>` and `<unless>` statements. These statements allow modules to be loaded on specific servers or during holiday events.
+- The maps display gamemode can be specified with the `<gamemode>` element.
+- Added a [shield kit module](/docs/modules/gear/kits/#shield-kit-removable) that gives a player an absorption hearts recharging shield.
+- [Pickups module](/docs/modules/gear/pickups) for location specific kit pickups.
+  ***
+
+<span className="badge badge--info">Removed</span>
+<br />
+
+- The `<multitrade/>` tag has been removed, it is now always enabled.
+
+### Changes in 1.3.6
+
+<span className="badge badge--danger">Breaking</span>
+<br />
+
+- Regions for cores, destroyables, wools, portals & score boxes must be defined in a `<region>` sub-element or referenced in a `region` attribute.
+
+  - ```xml
+    <core>
+        <region>
+            <cuboid min="..." max="..."/>
+        </region>
+    </core>
+    <core region="my-region"/>
+    ```
+  - Similarly spawn regions must be defined in a `<regions>` sub-element or referenced in a `regions` attribute.
+  - ```xml
+    <spawns>
+        <spawn team="red">
+            <regions yaw="90">
+                <cuboid min="1,0,2" max="3,0,4"/>
+                <cylinder base="7,8,9" radius="5" height="0"/>
+            </regions>
+        </spawn>
+    </spawns>
+    ```
+
+- Everything scores 0 points by default, this means you have to explicitly define `<kills>` and `<deaths>` in the score module if you want players to get points for killing players.
+- The `<playable>` region module has been removed, this should now be handled using filters.

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -95,7 +95,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
         <td>
           Filters, regions, and teams are always referenced by its ID.
           <br />
-          Disallowed <label>&lt;time&gt;</label> inside{" "}
+          Disallows <label>&lt;time&gt;</label> inside{" "}
           <label>&lt;score&gt;</label> or <label>&lt;blitz&gt;</label> &
           disallow <label>&lt;title&gt;</label> inside{" "}
           <label>&lt;blitz&gt;</label>.

--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -158,7 +158,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
 <span className="badge badge--danger">Breaking</span>
 <br />
 
-- The objectives filter will now always automatically derive team ownership for the objective from context. To match an objective without any specific team, the <label>any="true"</label> attribute needs to be specified.
+- The objectives filter will now always automatically derive team ownership for the objective from context. To match an objective without any specific team, the `any="true"` attribute needs to be specified.
   ***
 
 <span class="badge badge--success">New</span>
@@ -170,8 +170,7 @@ Mapmakers should always use the latest supported proto version, and this may be 
   - Kits now have [`give`, `take` & `lend` properties](/docs/modules/gear/kits#dynamic-kits).
   - Portals have [`forward`, `reverse` & `transit` properties](/docs/modules/mechanics/portals#portal-sub-elements).
   - Structures & [score boxes](/docs/modules/objectives/scoring#score-box-attributes) have a `trigger` property.
-- <span className="badge badge--secondary">Not implemented</span> Added a player
-  count filter.
+- Added a player count filter.
 - Added a `<grounded/>` filter to check if the player is standing on the ground.
 - Added `<match-started/>`, `<match-running/>` & `<match-finished/>` filters that are used to check the state of the current match.
 - New `pre-match-physics` attribute for the terrain module to enable physics events before the match starts.
@@ -189,11 +188,11 @@ Mapmakers should always use the latest supported proto version, and this may be 
 - Teams have an `id` attribute and are always referenced by it everywhere in the XML, **never** by name.
 - Standalone filter definitions are no longer wrapped in a `<filter>` tag, they start with an actual filter, just like regions, e.g.
 
-  - ```xml
-    <filters>
-      <team id="only-red">red-team</team>
-    </filters>
-    ```
+  ```xml
+  <filters>
+    <team id="only-red">red-team</team>
+  </filters>
+  ```
 
 - The region for an `<apply>` must be either a `region` attribute or a `<region>` sub-element. It cannot appear directly inside the `<apply>` tag.
 - Inline filters must always be a single tag, multiple tags are not accepted anywhere. To combine multiple filters, always use a compound filter like `<all>` or `<any>`. This change is retroactive, and affects _all_ proto versions.
@@ -204,41 +203,41 @@ Mapmakers should always use the latest supported proto version, and this may be 
 - Blitz titles are no longer a part of the [Blitz Module](/docs/modules/objectives/blitz), instead they are set using the map sub-element `<game>` and can be used with any gamemode.
 - Match time limit is no longer part of the `<score>` or `<blitz>` module, instead it is defined directly in the root element.
 
-  - ```xml
-    <map proto="1.4.0">
-    <time result="objectives">5m</time>
-    <!-- Other modules. -->
-    </map>
-    ```
+  ```xml
+  <map proto="1.4.0">
+  <time result="objectives">5m</time>
+  <!-- Other modules. -->
+  </map>
+  ```
 
   ***
 
-  <span class="badge badge--primary">Change</span>
+  <span class="badge badge--primary">Changes</span>
   <br />
 
 - The top-level tags `<filters>` and `<regions>` are now the same thing. You can define filters, regions, and `<apply>`s in either one (remember that regions are a type of filter, have been for a while now).
 - Any filter tag anywhere can have an `id` attribute.
 - The `<apply>` tag accepts both references and inline definitions for its `region`, `kit`, and all of its filter properties, e.g. the two tags below are equivalent:
 
-  - ```xml
-    <apply region="effect-pad" kit="effect-kit" filter="only-red" block="only-leaves" />
-    <apply>
-        <region>
-            <cuboid min="1,2,3" max="4,5,6"/> <!-- effect-pad -->
-        </region>
-        <kit>
-            <potion>...</potion> <!-- effect-kit -->
-        </kit>
-        <filter>
-            <team>red-team</team>
-        </filter>
-        <block>
-            <material>leaves</material>
-        </block>
-    </apply>
-    ```
+  ```xml
+  <apply region="effect-pad" kit="effect-kit" filter="only-red" block="only-leaves"/>
+  <apply>
+      <region>
+          <cuboid min="1,2,3" max="4,5,6"/> <!-- effect-pad -->
+      </region>
+      <kit>
+          <potion>...</potion> <!-- effect-kit -->
+      </kit>
+      <filter>
+          <team>red-team</team>
+      </filter>
+      <block>
+          <material>leaves</material>
+      </block>
+  </apply>
+  ```
 
-- The `safe` and `spread` attributes of spawns can now be combined.
+- The [`safe` and `spread` attributes](/docs/modules/mechanics/spawns#spawn--default-element-attributes) of spawns can now be combined.
 - A items slot attribute is no longer required in kits. This attribute now also accepts Mojang slot names e.g. `slot.hotbar.8` or `armor.head`.
   ***
 
@@ -263,16 +262,18 @@ Mapmakers should always use the latest supported proto version, and this may be 
 
 - Regions for cores, destroyables, wools, portals & score boxes must be defined in a `<region>` sub-element or referenced in a `region` attribute.
 
-  - ```xml
-    <core>
-        <region>
-            <cuboid min="..." max="..."/>
-        </region>
-    </core>
-    <core region="my-region"/>
-    ```
+  ```xml
+  <core>
+      <region>
+          <cuboid min="..." max="..."/>
+      </region>
+  </core>
+  <core region="my-region"/>
+  ```
+
   - Similarly, spawn regions must be defined in a `<regions>` sub-element or referenced in a `regions` attribute.
-  - ```xml
+
+    ```xml
     <spawns>
         <spawn team="red">
             <regions yaw="90">

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,6 +1,10 @@
 module.exports = {
   Modules: {
-    General: ["modules/general/introduction", "modules/general/main"],
+    General: [
+      "modules/general/introduction",
+      "modules/general/main",
+      "modules/general/proto",
+    ],
     Information: [
       "modules/information/broadcasts",
       "modules/information/rules",


### PR DESCRIPTION
I started working on this back in June and occasionally checked it since then. This pull request will add a new page documenting the protocol versions that are used to define what iteration of PGM a certain map was created for and changes the recommended version from `1.4.0` to `1.4.2`.

Some thing to consider in this pull request are:
* I slightly changed the second paragraph of the Main Map Element page so it does not repeat the content found in the new Protocol Versions page.
* ~~This does not have information on even earlier protocol versions, such as 1.3.0 and below (since it's not mentioned on the [original docs.oc.tc page](https://docs.oc.tc/modules/proto) and I do not have enough knowledge in Java to read PGM's source code)~~
  * This is no longer necessary, since modern PGM will not load 1.3.0 maps and older.
* The page's layout- I kept it mostly the same from its original version, reworded some sentences, and hyperlinked existing or re-implemented features mentioned in the changelog section. [A screenshot of what it'll look like](https://i.imgur.com/FX37yV1.png)

I will leave this as a draft to allow for feedback and improvements that may be needed
_*second attempt at a proper pull request on a new branch as I messed up the rebase on a different branch_

Signed-off-by: TheRealPear <20259871+TheRealPear@users.noreply.github.com>