### PR TITLE
Fix Attribute Modifier link

### DIFF
--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -71,7 +71,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
           <label>{`<attribute> </attribute>`}</label>
         </td>
         <td>
-          <a href="#attributes">Attribute Modifier</a>
+          <a href="/docs/reference/items/attributes">Attribute Modifier</a>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Changes the "Attribute Modifier" text to link to https://pgm.dev/docs/reference/items/attributes, instead of the nonexistent https://pgm.dev/docs/modules/gear/items#attributes