### PR TITLE
Add projectile precise attribute and missing required labels

### DIFF
--- a/docs/modules/gear/classes.mdx
+++ b/docs/modules/gear/classes.mdx
@@ -58,8 +58,8 @@ Classes allow the player to pick a specific class at the beginning of the game w
           <label>name</label>
         </td>
         <td>
-          <span className="badge badge--danger">Required</span> The class's
-          name, must be unique.
+          <span className="badge badge--danger">Required</span> 
+          The class's name, must be unique.
         </td>
         <td>
           <span className="badge badge--primary">String</span>
@@ -92,7 +92,10 @@ Classes allow the player to pick a specific class at the beginning of the game w
         <td>
           <label>icon</label>
         </td>
-        <td>Icon shown in the class picker menu.</td>
+        <td>
+          <span className="badge badge--danger">Required</span>
+          Icon shown in the class picker menu.
+        </td>
         <td>
           <a href="/docs/reference/items/inventory#material_matchers">
             Single Material Pattern
@@ -105,8 +108,8 @@ Classes allow the player to pick a specific class at the beginning of the game w
           <label>family</label>
         </td>
         <td>
-          <span className="badge badge--danger">Required</span> "group" of
-          classes.
+          <span className="badge badge--danger">Required</span> 
+          The "group" of classes.
         </td>
         <td>
           <a href="/docs/modules/gear/classes">Class Family Name</a>
@@ -145,7 +148,7 @@ Classes allow the player to pick a specific class at the beginning of the game w
           <label>restrict</label>
         </td>
         <td>
-          If set to <label>true</label> only OP's can use this class.
+          If set to <label>true</label>, only operators can use this class.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>

--- a/docs/modules/gear/projectiles.mdx
+++ b/docs/modules/gear/projectiles.mdx
@@ -64,8 +64,8 @@ or the item form of the custom projectile itself.
           <label>id</label>
         </td>
         <td>
-          Unique identifier used to reference this projectile from other places
-          in the XML.
+          <span className="badge badge--danger">Required</span>
+          Unique identifier used to reference this projectile from other places in the XML.
         </td>
         <td>
           <span className="badge badge--primary">String</span>
@@ -186,6 +186,16 @@ or the item form of the custom projectile itself.
         </td>
         <td></td>
       </tr>
+      <tr>
+        <td>
+          <label>precise</label>
+        </td>
+        <td>Whether the path of a thrown projectile should be precise in hitting a target.</td>
+        <td>
+          <span className="badge badge--primary">true/false</span>
+        </td>
+        <td>true</td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -242,7 +252,8 @@ or the item form of the custom projectile itself.
         velocity="3.5"
         damage="50"
         throwable="false"
-        cooldown="5s"/>
+        cooldown="5s"
+        precise="false"/>
 </projectiles>
 <!-- Apply the projectile to an item -->
 <kits>


### PR DESCRIPTION
Self-explanatory title, really.

* Minor grammar fix
* `precise` attribute added to the Attributes table (https://github.com/PGMDev/PGM/pull/1110)
* Mark `icon` as a required attribute in the Classes page (https://github.com/PGMDev/PGM/pull/1112)
* Mark projectile `id` as a required attribute

Signed-off-by: TheRealPear <20259871+TheRealPear@users.noreply.github.com>