### PR TITLE
Make docs more consistent and update external links

### DIFF
--- a/docs/modules/blocks/renewables.mdx
+++ b/docs/modules/blocks/renewables.mdx
@@ -140,7 +140,9 @@ specify blocks to renew. If neither are specified, the renewable affects all blo
           required for any single block to renew will depend on how many other
           blocks are waiting to be renewed by the same renewable.
           <br />
-          <i>This parameter cannot be combined with</i> <label> interval</label>
+          <em>
+            This parameter cannot be combined with <label>interval</label>.
+          </em>
         </td>
         <td>Blocks/second</td>
         <td>1</td>
@@ -150,14 +152,14 @@ specify blocks to renew. If neither are specified, the renewable affects all blo
           <label> interval</label>
         </td>
         <td>
-          Average time required for a block to renew. Unlike `rate`, this
+          Average time required for a block to renew. Unlike <label>rate</label>, this
           applies to each block individually, and blocks do not affect each
-          other's renewal time. A renewable with an `interval` can behave very
-          differently from a renewable with a `rate`, particularly if it is
-          large.
+          other's renewal time. A renewable with an <label>interval</label> can behave very
+          differently from a renewable with a <label>rate</label>, particularly if it is large.
           <br />
-          <i>This parameter cannot be combined with</i>
-          <label> rate</label>
+          <em>
+            This parameter cannot be combined with <label>rate</label>.
+          </em>
         </td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>

--- a/docs/modules/blocks/structures.mdx
+++ b/docs/modules/blocks/structures.mdx
@@ -5,7 +5,7 @@ title: Structures
 
 Structures are sets of blocks that can be dynamically copied into the world in response to match events.
 The original structure is built into the map by the mapmaker and defined in XML with regions.
-When the match loads, the original structures will be cleared from the world and saved.
+When the match loads, the original structures will be saved and cleared from the world.
 
 Structures are brought to life by the `<dynamic>` element.
 This is an XML construct that causes a structure to appear at a specified location in reaction to a given filter.

--- a/docs/modules/blocks/structures.mdx
+++ b/docs/modules/blocks/structures.mdx
@@ -4,8 +4,8 @@ title: Structures
 ---
 
 Structures are sets of blocks that can be dynamically copied into the world in response to match events.
-The original structure is built into the map by the mapmaker, and defined in XML with regions.
-When the match loads, the original structures are cleared from the world and saved.
+The original structure is built into the map by the mapmaker and defined in XML with regions.
+When the match loads, the original structures will be cleared from the world and saved.
 
 Structures are brought to life by the `<dynamic>` element.
 This is an XML construct that causes a structure to appear at a specified location in reaction to a given filter.
@@ -28,7 +28,7 @@ Structures are a very powerful feature that can be used to implement an endless 
     <tbody>
       <tr>
         <td>
-          <label>{`<falling-blocks> </falling-blocks>`}</label>
+          <label>{`<structures> </structures>`}</label>
         </td>
         <td>Element containing all structures and dynamics.</td>
         <td>
@@ -219,7 +219,7 @@ Structures are a very powerful feature that can be used to implement an endless 
           >
             Property
           </span>
-          Filter used to determine when a stricture is <em>placed</em> when <label>
+          Filter used to determine when a structure is <em>placed</em> when <label>
             trigger
           </label> allows.
         </td>

--- a/docs/modules/environment/border.mdx
+++ b/docs/modules/environment/border.mdx
@@ -108,9 +108,9 @@ Attributes for multiple world borders can be applied for all borders by specifyi
         <td>
           Time after which this border takes effect.
           <br />
-          <i>
+          <em>
             Not compatible with the <label>when</label> property.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>

--- a/docs/modules/format/players.mdx
+++ b/docs/modules/format/players.mdx
@@ -62,10 +62,10 @@ This gamemode is not compatible with the teams module!
           Player limit -- normal players cannot join the match once it reaches
           this size.
           <br />
-          <i>
+          <em>
             Premium players may join over this limit until{" "}
             <label>max-overfill</label> is reached.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -80,9 +80,9 @@ This gamemode is not compatible with the teams module!
           Player overfill -- premium players cannot join the match once it
           reaches this size.
           <br />
-          <i>
+          <em>
             Must be greater than the defined <label>max</label>.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -109,8 +109,8 @@ This gamemode is not compatible with the teams module!
           <label>colors</label>
         </td>
         <td>
-          Auto assign a unique color to each player, works for up to 10 players
-          and then colors repeat.
+          Automatically assign a unique color to each player, works up to 10 players
+          before colors repeat.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>

--- a/docs/modules/format/teams.mdx
+++ b/docs/modules/format/teams.mdx
@@ -139,10 +139,10 @@ It is common for maps to only have 2 teams, although more are possible it usuall
           Maximum players for this team, normal players cannot join the team
           once it reaches this size.
           <br />
-          <i>
+          <em>
             Premium players may join over this limit until{" "}
             <label>max-overfill</label> is reached.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -156,9 +156,9 @@ It is common for maps to only have 2 teams, although more are possible it usuall
           Maximum players hard limit for this team, nobody can join the team
           once this limit is reached.
           <br />
-          <i>
+          <em>
             Must be greater than the defined <label>max</label>.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>

--- a/docs/modules/gear/classes.mdx
+++ b/docs/modules/gear/classes.mdx
@@ -121,8 +121,8 @@ Classes allow the player to pick a specific class at the beginning of the game w
           <label>sticky</label>
         </td>
         <td>
-          If set to <label>true</label> players can't change the class mid game,
-          instead they have to rejoin.
+          If set to <label>true</label>, players can't change the class mid-match,
+          instead they must rejoin.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -136,7 +136,9 @@ Classes allow the player to pick a specific class at the beginning of the game w
         <td>
           Specify if the class is the default class for new players.
           <br />
-          <i>One class must be set as the default.</i>
+          <em>
+            One class must be set as the default.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>

--- a/docs/modules/gear/crafting.mdx
+++ b/docs/modules/gear/crafting.mdx
@@ -201,7 +201,9 @@ Blank ingredient spots are specifed with a dot `.`
           </span>{" "}
           An ingredient used in this recipe.
           <br />
-          <i>Only one shape per recipe is allowed.</i>
+          <em>
+            Only one shape per recipe is allowed.
+          </em>
         </td>
         <td>
           <label>{`<row>`}</label>
@@ -375,10 +377,9 @@ Unlike a shaped recipe, shapeless recipes do not require that their items are ar
         <td>
           Amount of items of this type required for this recipe.
           <br />
-          <i>
-            Items must be in separate slots, not stacked, for this recipe to
-            work.
-          </i>
+          <em>
+            Items must be in separate slots, not stacked, for this recipe to work.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>

--- a/docs/modules/gear/item-mods.mdx
+++ b/docs/modules/gear/item-mods.mdx
@@ -249,7 +249,7 @@ the modify element does not currently support the projectile or grenade attribut
         <td>
           <label>name</label>
         </td>
-        <td>The item's display name.</td>
+        <td>The item's display name that appears when it is selected.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -259,7 +259,7 @@ the modify element does not currently support the projectile or grenade attribut
         <td>
           <label>lore</label>
         </td>
-        <td>Custom lore string.</td>
+        <td>Custom text that appears when a player hovers over the item in the inventory.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -270,8 +270,8 @@ the modify element does not currently support the projectile or grenade attribut
           <label>unbreakable</label>
         </td>
         <td>
-          Specify if this item is unbreakable, hides the durability bar in
-          minecraft.
+          Specify if this item is unbreakable and hides the durability bar in
+          Minecraft.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -285,7 +285,9 @@ the modify element does not currently support the projectile or grenade attribut
         <td>
           Leather armor color as a hexadecimal color. <label>RRGGBB</label>
           <br />
-          <i>Only applies to leather armor items.</i>
+          <em>
+            Only applies to leather armor items.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Hex Color</span>
@@ -299,10 +301,12 @@ the modify element does not currently support the projectile or grenade attribut
         <td>
           Potion type
           <br />
-          <i>Only applies to potion items.</i>
+          <em>
+            Only applies to potion items.
+          </em>
         </td>
         <td>
-          <a href="http://minecraft.gamepedia.com/Potion#Data_values">
+          <a href="https://minecraft.fandom.com/wiki/Potion#Data_values">
             Potion ID
           </a>
         </td>

--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -135,10 +135,10 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         <td>
           Slot where the item will be placed in the player's inventory.
           <br />
-          <i>
+          <em>
             If no slot is specified the item will be merged into the player's
             inventory.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/reference/items/inventory">Inventory Slot</a>
@@ -151,7 +151,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         </td>
         <td>
           The amount of items. Blocks can be given an infinite amount by using
-          "oo".
+          <label>oo</label>.
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -163,7 +163,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
           <label>damage</label>
         </td>
         <td>
-          The item's damage, used for items such as birch logs, red wool, potion
+          The item's damage value, used for items such as birch logs, red wool, potion
           types, etc.
         </td>
         <td>
@@ -176,8 +176,8 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
           <label>unbreakable</label>
         </td>
         <td>
-          Specify if this item is unbreakable, hides the durability bar in
-          minecraft.
+          Specify if this item is unbreakable and hides the durability bar in
+          Minecraft.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -188,7 +188,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         <td>
           <label>name</label>
         </td>
-        <td>The item's display name.</td>
+        <td>The item's display name that appears when it is selected.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -198,7 +198,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         <td>
           <label>lore</label>
         </td>
-        <td>Custom lore string.</td>
+        <td>Custom text that appears when a player hovers over the item in the inventory.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -211,7 +211,9 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         <td>
           Leather armor color as a hexadecimal color. <label>RRGGBB</label>
           <br />
-          <i>Only applies to leather armor items.</i>
+          <em>
+            Only applies to leather armor items.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Hex Color</span>
@@ -243,7 +245,9 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
           </a>
           Projectile explodes on impact.
           <br />
-          <i>Works with ender pearls, snowballs, eggs, and arrows.</i>
+          <em>
+            Works with ender pearls, snowballs, eggs, and arrows.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -759,7 +763,7 @@ Preferably books should be written in-game to ensure proper formatting, and then
 
 Any enchantment can be applied to any item and an item can have one or multiple enchantments.
 The enchantment type can be specified by its
-[Minecraft name](http://minecraft.gamepedia.com/Data_values#Enchantment_IDs) or
+[Minecraft name](https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening#Enchantment_IDs) or
 [Bukkit name](/docs/reference/items/enchantments).
 
 To store an enchantment in an enchanted book (instead of enchanting the book itself),

--- a/docs/modules/gear/kits.mdx
+++ b/docs/modules/gear/kits.mdx
@@ -107,8 +107,11 @@ Removable kits will be noted in the documentation where applicable.
           <label>overflow-warning</label>
         </td>
         <td>
-          Warn the player when the kit cannot give the player all of it's items.{" "}
-          <em>Defaults to standard translatable message</em>
+          Warn the player when the kit cannot give the player all of it's items.
+          <br />
+          <em>
+            Defaults to standard translatable message.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">String</span>
@@ -169,7 +172,9 @@ Removable kits will be noted in the documentation where applicable.
         <td>
           Enable or disable potion particles.
           <br />
-          <i>Potion particles are disabled for all players by default.</i>
+          <em>
+            Potion particles are disabled for all players by default.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>

--- a/docs/modules/gear/pickups.mdx
+++ b/docs/modules/gear/pickups.mdx
@@ -97,7 +97,9 @@ A `<point>` region does not return a randomized position but can still be used t
         <td>
           Entity used to show this pickup's location.
           <br />
-          Currently only accepts <label>ENDER CRYSTAL</label>
+          <em>
+            Currently only accepts <label>ENDER CRYSTAL</label>.
+          </em>
         </td>
         <td>
           <a href="/docs/reference/entities/entity-types">Entity Type</a>

--- a/docs/modules/gear/potions.mdx
+++ b/docs/modules/gear/potions.mdx
@@ -77,9 +77,10 @@ Effect IDs should be specified without their `minecraft:` prefix.
         </td>
         <td>
           Disables potion particles on an potion when set to true.
-          <i>
+          <br />
+          <em>
             <label>potion-particles</label> must be enabled to use this feature.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>

--- a/docs/modules/gear/projectiles.mdx
+++ b/docs/modules/gear/projectiles.mdx
@@ -193,9 +193,9 @@ or the item form of the custom projectile itself.
         <td>
           Whether the path of a thrown projectile should be precise in hitting a target.
           <br />
-          <i>
+          <em>
             This is only applicable if the projectile is <label>Fireball</label>, <label>LargeFireball</label>, <label>SmallFireball</label>, or <label>WitherSkull</label>.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -271,7 +271,7 @@ or the item form of the custom projectile itself.
 ### Modifying Bow Projectiles
 
 Bows can be modified to shoot a different projectile at a custom speed.
-The PGM plugin will calculate the damage the projectile does using the same formula as minecraft does for arrows.
+The PGM plugin will calculate the damage the projectile does using the same formula as Minecraft does for arrows.
 This means that a flying fish with a velocity of 40 will almost certainly kill you.
 Projectiles can also have custom [potion effects](/docs/modules/gear/potions) which are applied to the target when it is hit.
 

--- a/docs/modules/gear/repair-remove-keep.mdx
+++ b/docs/modules/gear/repair-remove-keep.mdx
@@ -7,7 +7,7 @@ title: Repair, Remove & Keep
 
 Defines tools that will be automatically repaired when dropped and picked up again.
 This will also merge items that are picked up, i.e., picking up an iron sword would result in it merging with your sword and repairing it.
-Repaired items will keep their enchantment, unlike vanilla minecraft where they will not.
+Repaired items will keep their enchantment, unlike vanilla Minecraft where they will not.
 
 This also works with non-tool items such as arrows.
 When people pick up item in the `<toolrepair>` module and they already have one of the same kind it gets merged into the existing item, if they don't have it they get it like normal.

--- a/docs/modules/gear/tnt.mdx
+++ b/docs/modules/gear/tnt.mdx
@@ -67,9 +67,9 @@ This license is revoked if a player kills too many of their teammates using TNT.
         <td>
           Modify the amount of items dropped by the explosion as a percentage.
           <br />
-          <i>
+          <em>
             Not valid when <label>blockdamage</label> is false.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">0 - 1.0</span>

--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -182,8 +182,8 @@ The maps version should follow the versioning schema `major.minor.patch`.
           <label>{`<phase>`}</label>
         </td>
         <td>
-          Phase of this map. Only maps with phase:`production` and
-          edition:`standard` show up on the website.
+          Phase of this map. Only maps with <label>production</label> and
+          <label>standard</label> show up on the website.
         </td>
         <td>
           <label>development</label>
@@ -254,7 +254,7 @@ The maps version should follow the versioning schema `major.minor.patch`.
 
 The authors and contributers elements provide information about who created and helped create the map. There can be multiple authors and contributors to a map. The contribution attribute should be used to specify what their contribution to the map was.
 
-A players name should **not** be used to credit them, instead their UUID should be used. A UUID is a unique user identifier that is used to keep track of players even if they change their name. You can check player UUID's at [mcuuid.net](http://mcuuid.net). If an author or contributor is defined without a UUID that player will not get any mapmaker perks on the map.
+A player's name should **not** be used to credit them, instead their UUID should be used. A UUID is a unique user identifier that is used to keep track of players even if they change their name. You can check player UUID's at [mcuuid.net](https://mcuuid.net/). If an author or contributor is defined without a UUID that player will not get any mapmaker perks on the map.
 
 #### Author or Contributor Sub-elements
 
@@ -341,7 +341,7 @@ A players name should **not** be used to credit them, instead their UUID should 
 
 <!-- People that contributed in some way to the map. -->
 <contributors>
-    <!-- Credit a person that doesn't have a minecraft account -->
+    <!-- Credit a person that doesn't have a Minecraft account -->
     <contributor contribution="A contribution">aHelper</contributor>
     <contributor uuid="3fbec7dd-0a5f-40bf-9d11-885a54507112" contribution="Some Help"/> <!-- Cubist -->
 </contributors>

--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -254,7 +254,7 @@ The maps version should follow the versioning schema `major.minor.patch`.
 
 The authors and contributers elements provide information about who created and helped create the map. There can be multiple authors and contributors to a map. The contribution attribute should be used to specify what their contribution to the map was.
 
-A player's name should **not** be used to credit them, instead their UUID should be used. A UUID is a unique user identifier that is used to keep track of players even if they change their name. You can check player UUID's at [mcuuid.net](https://mcuuid.net/). If an author or contributor is defined without a UUID that player will not get any mapmaker perks on the map.
+A player's name should **not** be used to credit them, instead their UUID should be used. A UUID is a unique user identifier that is used to keep track of players even if they change their name. You can check player UUIDs at [mcuuid.net](https://mcuuid.net/). If an author or contributor is defined without a UUID, that player will not get any mapmaker perks on the map.
 
 #### Author or Contributor Sub-elements
 

--- a/docs/modules/information/broadcasts.mdx
+++ b/docs/modules/information/broadcasts.mdx
@@ -101,10 +101,10 @@ It should not be used for generic server related messages.
         <td>
           Amount of times the message is repeated.
           <br />
-          <i>
+          <em>
             Infinite repetition can be specified by using <label>oo</label> as
             the duration.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>

--- a/docs/modules/mechanics/portals.mdx
+++ b/docs/modules/mechanics/portals.mdx
@@ -86,10 +86,10 @@ Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (
           </span>
           Region where this portals entrance is located.
           <br />
-          <i>
+          <em>
             Cannot combine an entrance region with <label>forward</label> or{" "}
             <label>transit</label> properties.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/modules/mechanics/regions">Region</a>
@@ -110,10 +110,10 @@ Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (
           Destination of the portal, teleports players to a random point inside the
           region.
           <br />
-          <i>
+          <em>
             Cannot combine an exit region with <label>reverse</label> or{" "}
             <label>transit</label> properties.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/modules/mechanics/regions">Randomize-able Region</a>
@@ -181,7 +181,9 @@ Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (
           Specify the direction the player is looking horizontally from
           -180&deg; to 180&deg;.
           <br />
-          <i>South 0, East -90, North 180 and West 90.</i>
+          <em>
+            South 0, East -90, North 180, and West 90.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -206,7 +208,9 @@ Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (
           Specify the direction the player is looking vertically from -90&deg;
           to 90&deg;.
           <br />
-          <i>-90 is straight up 90 is straight down.</i>
+          <em>
+            -90 is straight up, 90 is straight down.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -260,7 +264,9 @@ Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (
           Destination of the portal, teleports players to a random point inside the
           region.
           <br />
-          <i>Region is automatically filtered against block place.</i>
+          <em>
+            Region is automatically filtered against block place.
+          </em>
         </td>
         <td>
           <a href="/docs/modules/mechanics/regions">Randomize-able Regions</a>
@@ -335,10 +341,10 @@ Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (
           Apply forward transform on rising edge and reverse transform on falling
           edge.
           <br />
-          <i>
+          <em>
             Cannot combine <label>transit</label> property with{" "}
             <label>forward</label> or <label>reverse</label> properties.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/modules/mechanics/filters#dynamic-filters">

--- a/docs/modules/mechanics/regions.mdx
+++ b/docs/modules/mechanics/regions.mdx
@@ -45,7 +45,9 @@ See the [Properly Defining Regions](/docs/guides/xml-pointers/regions) guide for
             X2,Y2,Z2
           </label>.
           <br />
-          <i>Only block bounded when using finite coordinates.</i>
+          <em>
+            Only block bounded when using finite coordinates.
+          </em>
         </td>
         <td className="text-right">
           <span className="badge badge--primary">Randomize-able</span>
@@ -60,7 +62,9 @@ See the [Properly Defining Regions](/docs/guides/xml-pointers/regions) guide for
             R
           </label> and a height of <label>H</label>.
           <br />
-          <i>Only block bounded when using a finite radius.</i>
+          <em>
+            Only block bounded when using a finite radius.
+          </em>
         </td>
         <td className="text-right">
           <span className="badge badge--primary">Randomize-able</span>
@@ -82,7 +86,9 @@ See the [Properly Defining Regions](/docs/guides/xml-pointers/regions) guide for
             R
           </label>.
           <br />
-          <i>Only block bounded when using a finite radius.</i>
+          <em>
+            Only block bounded when using a finite radius.
+          </em>
         </td>
         <td></td>
       </tr>
@@ -90,10 +96,10 @@ See the [Properly Defining Regions](/docs/guides/xml-pointers/regions) guide for
         <td>
           <label>{`<point id="abc">X,Y,Z</point>`}</label>
           <br />A single point region located at <label>X,Y,Z</label>.<br />
-          <i>
+          <em>
             This region will always return the same location even when used in a
             randomized context, e.g., spawns.
-          </i>
+          </em>
         </td>
         <td className="text-right">
           <span className="badge badge--primary">Randomize-able</span>
@@ -126,10 +132,10 @@ See the [Properly Defining Regions](/docs/guides/xml-pointers/regions) guide for
           <br />A circle located at <label>X,Z</label> with a radius of <label>
             R
           </label>. <br />
-          <i>
+          <em>
             The region goes from 0 to map height, i.e. PGM doesn't check the
             players Y position.
-          </i>
+          </em>
         </td>
       </tr>
       <tr>
@@ -204,8 +210,8 @@ The example below defines a region with a diagonal boundary:
 The above and below regions can be used to conveniently define axis-aligned half-spaces:
 
 ```xml
-<above y="50"/>         <!-- Everything above Y=50 -->
-<below x="0" z="0"/>    <!-- Everything in the -X, -Z quadrant -->
+<above y="50"/>      <!-- Everything above Y=50 -->
+<below x="0" z="0"/> <!-- Everything in the -X, -Z quadrant -->
 ```
 
 ## Applying Things to Regions
@@ -740,7 +746,9 @@ Input can be a region, a region modifier or simply an exact `X,Y,Z` coordinate.
           Specifies what direction the player is looking horizontally from
           -180&deg; to 180&deg;.
           <br />
-          <i>South 0&deg;, East -90&deg;, North 180&deg; and West 90&deg;.</i>
+          <em>
+            South 0&deg;, East -90&deg;, North 180&deg;, and West 90&deg;.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">-180 to 180</span>
@@ -754,7 +762,9 @@ Input can be a region, a region modifier or simply an exact `X,Y,Z` coordinate.
           Specifies what direction the player is looking vertically from
           -90&deg; to 90&deg;.
           <br />
-          <i>-90&deg; is straight up 90&deg; is straight down.</i>
+          <em>
+            -90&deg; is straight up, 90&deg; is straight down.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">-90 to 90</span>
@@ -767,10 +777,10 @@ Input can be a region, a region modifier or simply an exact `X,Y,Z` coordinate.
         <td>
           Specify the exact block coordinates that the player should look at.
           <br />
-          <i>
+          <em>
             This attribute will negate any angles set by the <label>yaw</label>{" "}
             and <label>pitch</label> attributes.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">X,Y,Z</span>
@@ -812,4 +822,4 @@ Input can be a region, a region modifier or simply an exact `X,Y,Z` coordinate.
 </div>
 
 `NOTE:` The pitch and yaw arguments can also accept a `X,Y,Z` coordinate. <br/>
-`TIP:` Copy the yaw and pitch from the F3 screen in minecraft (the `Facing: Direction (Axis) (Yaw/Pitch)` line).
+`TIP:` Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (Axis) (Yaw/Pitch)` line).

--- a/docs/modules/mechanics/spawners.mdx
+++ b/docs/modules/mechanics/spawners.mdx
@@ -107,6 +107,7 @@ define items and makes use of a specific <a href="/docs/modules/mechanics/region
           Used to randomize the spawn interval. Combine this with{" "}
           <label>max-delay</label> to create random intervals in between two
           values.{" "}
+          <br />
           <em>
             Cannot be combined with <label>delay</label>.
           </em>
@@ -126,6 +127,7 @@ define items and makes use of a specific <a href="/docs/modules/mechanics/region
           Used to randomize the spawn interval. Combine this with{" "}
           <label>min-delay</label> to create random intervals in between two
           values.{" "}
+          <br />
           <em>
             Cannot be combined with <label>delay</label>.
           </em>

--- a/docs/modules/mechanics/spawns.mdx
+++ b/docs/modules/mechanics/spawns.mdx
@@ -54,7 +54,9 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
           </span>
           The spawn for observers and teams without a spawn.
           <br />
-          <i>Only one default spawn element is allowed per map.</i>
+          <em>
+            Only one default spawn element is allowed per map.
+          </em>
         </td>
         <td>
           <label>{`<regions>`}</label>
@@ -84,7 +86,9 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
         <td>
           The team this spawn applies to.
           <br />
-          <i>Not needed for team-less gamemodes.</i>
+          <em>
+            Not needed for team-less gamemodes.
+          </em>
         </td>
         <td>
           <a href="/docs/modules/format/teams">Team ID</a>
@@ -109,9 +113,9 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
           Spawns players at the next region in a list if the one prior to it
           isn't safe.
           <br />
-          <i>
+          <em>
             Requires the <label>safe</label> attribute set to true.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -239,10 +243,10 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
         <td>
           The exact block coordinates that the player looks at when spawned.
           <br />
-          <i>
+          <em>
             This attribute will negate any angles set by the <label>yaw</label>{" "}
             and <label>pitch</label> attributes.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">X,Y,Z</span>
@@ -256,7 +260,9 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
         <td>
           The horizontal angle the player looks to when spawned.
           <br />
-          <i>South 0, East -90, North 180, and West 90.</i>
+          <em>
+            South 0, East -90, North 180, and West 90.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">-180 to 180</span>
@@ -270,7 +276,9 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
         <td>
           The vertical angle the player looks to when spawned.
           <br />
-          <i>-90 is straight up, 90 is straight down.</i>
+          <em>
+            -90 is straight up, 90 is straight down.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">-90 to 90</span>
@@ -281,7 +289,7 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
   </table>
 </div>
 
-`TIP:` Copy the yaw and pitch from the F3 screen in minecraft (the `Facing: Direction (Axis) (Yaw/Pitch)` line).
+`TIP:` Copy the yaw and pitch from the F3 screen in Minecraft (the `Facing: Direction (Axis) (Yaw/Pitch)` line).
 
 _Examples_
 

--- a/docs/modules/objectives/blitz.mdx
+++ b/docs/modules/objectives/blitz.mdx
@@ -125,5 +125,5 @@ _Example_
 ```
 
 ```xml
-<blitz/>    <!-- Use the default blitz settings -->
+<blitz/> <!-- Use the default blitz settings -->
 ```

--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -102,7 +102,7 @@ Other uses of control points include unlocking an area of the map using objectiv
           Specify if this objective is required to win the match.
           <br />
           Teams completing all of their required objectives will win regardless
-          of score or blitz configuration.
+          of score or Blitz configuration.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -259,7 +259,9 @@ Other uses of control points include unlocking an area of the map using objectiv
           The rate for a control point to decay from captured to neutral.
           Applies when nobody is dominating the point.
           <br />
-          <i>Takes precedence over <label>decay-rate</label>.</i>
+          <em>
+            Takes precedence over <label>decay-rate</label>.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -279,17 +281,17 @@ Other uses of control points include unlocking an area of the map using objectiv
             Deprecated
           </span>
           Capture progress is retained even if capturing is interrupted.
-          <br/>
+          <br />
           If incremental is true, sets <label>recovery-rate</label> to 1,
           <label>decay-rate</label> to 0, and <label>owned-decay-rate</label> to 0.
-          <br/>
+          <br />
           If incremental is false, <label>recovery-rate</label> and
           <label>decay-rate</label> are both infinite, and <label>owned-decay-rate</label> is 0.
           <br />
-          <i>
-            Has been replaced with the recovery & decay attributes which allow
-            much more control over progress.
-          </i>
+          <em>
+            This has been replaced with the recovery & decay attributes which allow
+            more control over progress.
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -396,10 +398,10 @@ Other uses of control points include unlocking an area of the map using objectiv
         <td>
           Filter the materials modified when updating the progress regions.
           <br />
-          <i>
+          <em>
             Defaults to wool, carpet, stained clay, stained glass & stained
             glass panes.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/modules/mechanics/filters">Block Filter</a>

--- a/docs/modules/objectives/ctf.mdx
+++ b/docs/modules/objectives/ctf.mdx
@@ -359,10 +359,10 @@ Filters can be used to control who can pickup/capture the flag and when.
           If the flag has an <label>owner</label>, that team receives the
           points. Otherwise, the carrier's team receives them.
           <br />
-          <i>
+          <em>
             A negative number can be used to take away points rather than give
             them.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -380,10 +380,10 @@ Filters can be used to control who can pickup/capture the flag and when.
           If the flag has an <label>owner</label>, that team receives the
           points. Otherwise, the carrier's team receives them.
           <br />
-          <i>
+          <em>
             A negative number can be used to take away points rather than give
             them.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -809,10 +809,10 @@ The `permanent` option can be used to make a post into something like a [monumen
           When a flag is captured and returned to this post, remove the flag
           from the game and consider it a completed objective.
           <br />
-          <i>
+          <em>
             The objective is credited to the <label>owner</label> of the post,
             which is required in this case.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -840,9 +840,9 @@ The `permanent` option can be used to make a post into something like a [monumen
           Points awarded per second to this post's owner while any flag is at
           the post.
           <br />
-          <i>
+          <em>
             Requires the <label>owner</label> attribute to be set.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -888,10 +888,10 @@ The `permanent` option can be used to make a post into something like a [monumen
           Time between a flag being captured/recovered and respawning at this
           post.
           <br />
-          <i>
+          <em>
             During this time, the flag is completely gone, giving defenders a
             chance to return to their base.
-          </i>
+          </em>
         </td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>
@@ -916,10 +916,10 @@ The `permanent` option can be used to make a post into something like a [monumen
           Speed that a flag "moves" to respawn at this post, after being
           captured/recovered.
           <br />
-          <i>
+          <em>
             This is an alternative to <label>respawn-time</label> that
             calculates the time based on the distance the flag must travel.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">M/s</span>
@@ -943,7 +943,9 @@ The `permanent` option can be used to make a post into something like a [monumen
         <td>
           Fallback spawn for flag if all other post filters deny.
           <br />
-          <i>The fallback will be used even if it's own post filter denies.</i>
+          <em>
+            The fallback will be used even if its own post filter denies.
+          </em>
         </td>
         <td>
           <a href="/docs/modules/objectives/ctf#posts">Post ID</a>
@@ -1084,10 +1086,10 @@ If the net has no owner, then the player carrying the flag will receive the poin
           If the net has an <label>owner</label>, that team receives the points.
           Otherwise, the carrier's team receives them.
           <br />
-          <i>
+          <em>
             A negative number can be used to take away points rather than give
             them.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">Number</span>
@@ -1115,10 +1117,10 @@ If the net has no owner, then the player carrying the flag will receive the poin
           <br />
           This is a list of flag IDs, separated with spaces.
           <br />
-          <i>
+          <em>
             Attribute can not be specified on nets that are defined inside a
             flag.
-          </i>
+          </em>
         </td>
         <td>
           <span className="badge badge--primary">String</span>

--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -87,7 +87,7 @@ This can also be avoided by keeping the lava far away enough from the core and n
           Specify if this objective is required to win the match.
           <br />
           Teams completing all of their required objectives will win regardless
-          of score or blitz configuration.
+          of score or Blitz configuration.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>

--- a/docs/modules/objectives/dtm.mdx
+++ b/docs/modules/objectives/dtm.mdx
@@ -90,7 +90,7 @@ Completion specifies how much of the material(s) inside of the monument region m
         <td>
           Specify if this objective is required to win the match. Teams
           completing all of their required objectives will win regardless of
-          score or blitz configuration.
+          score or Blitz configuration.
         </td>
         <td>
           <span className="badge badge--primary">true/false</span>
@@ -122,8 +122,7 @@ Completion specifies how much of the material(s) inside of the monument region m
         </td>
         <td>
           The destroyables materials, multiple materials are separated with a
-          semicolon
-          <label>;</label>
+          semicolon <label>;</label>.
         </td>
         <td>
           <a href="/docs/reference/items/inventory#material_matchers">

--- a/docs/modules/objectives/monument-modes.mdx
+++ b/docs/modules/objectives/monument-modes.mdx
@@ -67,9 +67,7 @@ Each `<mode>` has configurable characteristics that define it.
         <td>
           <span className="badge badge--danger">Required</span>
           Time from the start of the game till this mode takes effect. If a filter
-          is defined, then it will be the time since the filter passes <label>
-            ALLOW
-          </label>.
+          is defined, then it will be the time since the filter passes <label>ALLOW</label>.
         </td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>
@@ -128,8 +126,7 @@ Each `<mode>` has configurable characteristics that define it.
         <td>
           The time before a mode is over to show it in the BossBar.
           <br />
-          If show-before is set to 0 the mode is not shown in the BossBar at
-          all.
+          If <label>show-before</label> is set to 0, the mode is not shown in the boss bar at all.
         </td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>

--- a/docs/reference/items/attributes.mdx
+++ b/docs/reference/items/attributes.mdx
@@ -38,7 +38,9 @@ Players or mobs carrying or wearing items with these attributes will have the ef
         <td>
           Resistance to knockback from attacks, explosions, and projectiles.
           <br />
-          <i>1.0 is full knockback resistance.</i>
+          <em>
+            1.0 is full knockback resistance.
+          </em>
         </td>
         <td>0.0</td>
         <td>0.0</td>
@@ -120,4 +122,4 @@ Players or mobs carrying or wearing items with these attributes will have the ef
   </table>
 </div>
 
-Incomplete list, copied from: [Minecraft Wiki Attributes](http://minecraft.gamepedia.com/Attribute)
+Incomplete list, copied from: [Minecraft Wiki Attributes](https://minecraft.fandom.com/wiki/Attribute).

--- a/docs/reference/items/enchantments.mdx
+++ b/docs/reference/items/enchantments.mdx
@@ -3,7 +3,7 @@ id: enchantments
 title: Enchantments
 ---
 
-Enchantments can be referenced by their Bukkit or [Minecraft](http://minecraft.gamepedia.com/Data_values#Enchantment_IDs) name.
+Enchantments can be referenced by their Bukkit or [Minecraft](https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening#Enchantment_IDs) name.
 Bukkit enchantment names are not case sensitive and a space can be used instead of an underscore.
 
 :::note

--- a/docs/reference/items/inventory.mdx
+++ b/docs/reference/items/inventory.mdx
@@ -11,7 +11,7 @@ import Materials from "../../../src/components/materials";
   </div>
   <div className="col col--6">
     <p>
-      <img alt="Inv Slots" src="https://i.imgur.com/cShqe87.png" />
+      <img alt="Inventory slots" src="https://i.imgur.com/cShqe87.png" />
     </p>
   </div>
   <div className="col col--6">
@@ -1601,7 +1601,7 @@ Use `~armor`, `~block`, `~food`, `~flower`, `~redstone` etc. to filter by tags.
   <tr>
     <td>99</td>
     <td>
-      <a href="http://minecraft.gamepedia.com/Mushroom_(block)#Block_data">
+      <a href="https://minecraft.fandom.com/wiki/Mushroom_Block#ID">
         <i className="fa fa-fw fa-external-link-square"></i>
       </a>
     </td>
@@ -1613,7 +1613,7 @@ Use `~armor`, `~block`, `~food`, `~flower`, `~redstone` etc. to filter by tags.
   <tr>
     <td>100</td>
     <td>
-      <a href="http://minecraft.gamepedia.com/Mushroom_(block)#Block_data">
+      <a href="https://minecraft.fandom.com/wiki/Mushroom_Block#ID">
         <i className="fa fa-fw fa-external-link-square"></i>
       </a>
     </td>
@@ -4219,7 +4219,7 @@ Use `~armor`, `~block`, `~food`, `~flower`, `~redstone` etc. to filter by tags.
     <td className="data">50</td>
     <td>
       <label>MONSTER_EGG</label> NBT data is used to specify the mob:
-      <a href="http://minecraft.gamepedia.com/Spawn_Egg#Data_values">
+      <a href="https://minecraft.fandom.com/wiki/Spawn_Egg#Data_values">
         Spawn egg, Data Values
       </a>
     </td>


### PR DESCRIPTION
* Structures table incorrectly started with `falling-blocks` and corrected a typo
* Changed every sentences in italic to use \<em> instead of \<i> for proper semantic (newer pages were using this, so I decided to update older docs so it matches up; it also helps people with screen readers if there is anyone using one)
* Changed Gamepedia links to Fandom links (also checked and made sure most information on relevant articles were accurate for Minecraft 1.8)
* Minor grammar correction and fixed some labels

Signed-off-by: TheRealPear <20259871+TheRealPear@users.noreply.github.com>