### PR TITLE
Add missing filters info and corrected info on some modules

### DIFF
--- a/docs/modules/blocks/enderchests.mdx
+++ b/docs/modules/blocks/enderchests.mdx
@@ -9,12 +9,11 @@ The `<enderchest>` tag can contain any number of `<dropoff>` tags. Each `<dropof
 determine where and when items should be dropped from the Ender chest.
 
 Dropoffs handle taking a player's Ender chest inventory and dropping it on the ground at a defined region or it can completely erase it.
-This can be triggered with a filter or once the player switches team or leaves the server.
+This is triggered once the player switches teams or stops participating in the match.
 
 :::caution
-Ensure that any maps with Ender chests are loaded on a server using the latest
-version of PGM available. Pre-existing Ender chests in previous versions of
-PGM are not supported and will allow players to transfer items across matches.
+Ensure that any maps with Ender chests are loaded on a server using PGM version `0.15` or newer. 
+Pre-existing Ender chests in previous versions of PGM are not supported and will allow players to transfer items across matches.
 Additionally, players cannot place Ender chests under any circumstances.
 :::
 
@@ -57,6 +56,41 @@ Additionally, players cannot place Ender chests under any circumstances.
   </table>
 </div>
 
+### Enderchest Attributes
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th style={{ minWidth: "130px" }}>Attribute</th>
+        <th>Description</th>
+        <th>Value</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>fallback</label>
+        </td>
+        <td>
+          Specify a fallback operation for when no drop-off passes the filters.<br />
+          <label>KEEP</label> will maintain items when the player leaves a match.<br />
+          <label>DELETE</label> will clear the content of a player's Ender chest if they leave a match.
+          Under <label>AUTO</label>, it will acts as <label>DELETE</label> if no drop-offs are 
+          defined, otherwise it will act as <label>KEEP</label>. 
+        </td>
+        <td>
+          <label>AUTO</label>, <label>KEEP</label>, <label>DELETE</label>
+        </td>
+        <td>
+          <label>AUTO</label>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ### Dropoff Attributes
 
 <div className="table-container">
@@ -85,7 +119,7 @@ Additionally, players cannot place Ender chests under any circumstances.
           Region in which a player's Ender chest content will be dropped off.
         </td>
         <td>
-          <a href="/docs/modules/mechanics/regions">Region</a>
+          <a href="/docs/modules/mechanics/regions">Randomize-able Region</a>
         </td>
         <td />
       </tr>
@@ -101,81 +135,13 @@ Additionally, players cannot place Ender chests under any circumstances.
             Property
           </span>
           <span className="badge badge--danger">Required</span>
-          Filter which determine when the content should be dropped.
+          Filter to determine whether to drop off Ender chest content at this location
+          or attempt the next location (if any).
         </td>
         <td>
           <a href="/docs/modules/mechanics/filters">Filter</a>
         </td>
         <td />
-      </tr>
-      <tr>
-        <td>
-          <label>fallback</label>
-        </td>
-        <td>
-          Specify a fallback location option for when no drop-off locations are
-          defined.
-          <br />
-          <em>
-            Cannot be combined with <label>region</label>.
-          </em>
-        </td>
-        <td>
-          <label>AUTO</label>, <label>KEEP</label>, <label>DELETE</label>
-        </td>
-        <td>
-          <label>AUTO</label>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-
-### Dropoff Sub-elements
-
-<div className="table-container">
-  <table>
-    <thead>
-      <tr>
-        <th>Element</th>
-        <th>Description</th>
-        <th>Value/Children</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <label>{`<region>`}</label>
-        </td>
-        <td>
-          <span
-            className="badge badge--secondary"
-            title="Can be either this sub-element or an attribute."
-          >
-            Property
-          </span>
-          The region the drop-off applies to.
-        </td>
-        <td>
-          <a href="/docs/modules/mechanics/regions">Bounded Regions</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <label>{`<filter>`}</label>
-        </td>
-        <td>
-          <span
-            className="badge badge--secondary"
-            title="Can be either this sub-element or an attribute."
-          >
-            Property
-          </span>
-          Filter which blocks are renewed.
-        </td>
-        <td>
-          <a href="/docs/modules/mechanics/filters">Filters</a>
-        </td>
       </tr>
     </tbody>
   </table>
@@ -188,16 +154,20 @@ _Examples_
 ```xml
 <!-- Add drop-off locations for when player switches teams or leave the match -->
 <enderchest>
+    <!-- Each drop-off requires a region & filter attribute -->
     <dropoff region="red-spawn" filter="red-only"/>
     <dropoff region="blue-spawn" filter="blue-only"/>
 </enderchest>
 ```
 
-#### Fallback
+#### Fallback Behavior
 
 If you want Ender chest contents to not drop upon a certain event, you can specify what PGM will do with the inventory.
 This will also be used when a drop-off is not possible.
 By default, PGM will use `AUTO` if neither regions nor a fallback preference are specified.
+`KEEP` will cause PGM to maintain a player's Ender chest if they leave. Upon rejoining, the Ender chest
+will have the same inventory as before.
+`DELETE` will cause PGM to clear a player's Ender chest if they leave. Upon rejoining, the Ender chest will be empty.
 
 ```xml
 <!-- Specify a fallback option for when no drop-off locations are defined -->

--- a/docs/modules/environment/time.mdx
+++ b/docs/modules/environment/time.mdx
@@ -4,9 +4,7 @@ title: Time & Dimension
 description: You can use these time and dimension modules to have a finer control over your map's lighting and mood.
 ---
 
-### Time
-
-#### Time Set
+### Time Set
 
 Sets the map to use a certain time on match load, measured in ticks.
 
@@ -17,7 +15,7 @@ Sets the map to use a certain time on match load, measured in ticks.
 </world>
 ```
 
-#### Random Time
+### Random Time
 
 World time can be set from one of six possible times at random when a match loads.
 
@@ -29,11 +27,11 @@ World time can be set from one of six possible times at random when a match load
 </world>
 ```
 
-#### Time Lock
+### Time Lock
 
 Locks the time to a certain time, either from `<timeset>` or from the world data.
 Time lock must be specifically turned off if one wishes to have the time cycle.
-This can also be accomplished with the `doDaylightCycle` [gamerule](/docs/modules/mechanics/gamerules).
+This can also be accomplished with the [`doDaylightCycle` gamerule](/docs/modules/mechanics/gamerules).
 
 ```xml
 <world>

--- a/docs/modules/format/players.mdx
+++ b/docs/modules/format/players.mdx
@@ -59,7 +59,7 @@ This gamemode is not compatible with the teams module!
           <label>max</label>
         </td>
         <td>
-          Player limit -- normal players cannot join the match once it reaches
+          Player limit &#8212; normal players cannot join the match once it reaches
           this size.
           <br />
           <em>
@@ -77,7 +77,7 @@ This gamemode is not compatible with the teams module!
           <label>max-overfill</label>
         </td>
         <td>
-          Player overfill -- premium players cannot join the match once it
+          Player overfill &#8212; premium players cannot join the match once it
           reaches this size.
           <br />
           <em>

--- a/docs/modules/gear/item-mods.mdx
+++ b/docs/modules/gear/item-mods.mdx
@@ -306,7 +306,7 @@ the modify element does not currently support the projectile or grenade attribut
           </em>
         </td>
         <td>
-          <a href="https://minecraft.fandom.com/wiki/Potion#Data_values">
+          <a href="https://minecraft.wiki/w/Potion#Data_values">
             Potion ID
           </a>
         </td>

--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -190,7 +190,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         </td>
         <td>The item's display name that appears when it is selected.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td></td>
       </tr>
@@ -200,7 +200,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
         </td>
         <td>Custom text that appears when a player hovers over the item in the inventory.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td></td>
       </tr>
@@ -407,7 +407,7 @@ A player's skin data can be found by using `https://sessionserver.mojang.com/ses
         <td>
           <label>name</label>
         </td>
-        <td>The heads display name.</td>
+        <td>The head's display name.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -951,7 +951,7 @@ You can define custom explosion designs when creating and giving a firework rock
 
 Any enchantment can be applied to any item and an item can have one or multiple enchantments.
 The enchantment type can be specified by its
-[Minecraft name](https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening#Enchantment_IDs) or
+[Minecraft name](https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Enchantment_IDs) or
 [Bukkit name](/docs/reference/items/enchantments).
 
 To store an enchantment in an enchanted book (instead of enchanting the book itself),

--- a/docs/modules/gear/kits.mdx
+++ b/docs/modules/gear/kits.mdx
@@ -576,9 +576,9 @@ affect a modifier applied by a different kit.
 
 **Attribute Operations**
 
-- `add` Add amount
-- `base` Multiply amount by base value and add it
-- `multiply` Multiply by amount
+- `add` &#8212; Add amount
+- `base` &#8212; Multiply amount by base value and add it
+- `multiply` &#8212; Multiply by amount
 
 ##### Attribute Kit Elements
 
@@ -852,7 +852,7 @@ This element's enabled attribute can be used to disable double-jump inside regio
         <td>
           <label>recharge-time</label>
         </td>
-        <td>Recharge time till the player can double jump again.</td>
+        <td>Recharge time until the player can double jump again.</td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
@@ -884,7 +884,7 @@ This element's enabled attribute can be used to disable double-jump inside regio
 
 The fly kit gives players which it is applied to the ability to fly.
 It also allows modification of the speed at which they fly.
-If no attributes are specified can-fly defaults to true.
+If no attributes are specified, `can-fly` defaults to true.
 
 <div className="table-container">
   <table>
@@ -899,7 +899,7 @@ If no attributes are specified can-fly defaults to true.
         <td>
           <label>{`<fly/>`}</label>
         </td>
-        <td>Control the player's flying ability</td>
+        <td>Control the player's flying ability.</td>
       </tr>
     </tbody>
   </table>
@@ -936,9 +936,9 @@ If no attributes are specified can-fly defaults to true.
           Set if the player is currently flying.
           <br />
           <i>
-            To enable flying
+            To enable flying,
             <label>can-fly</label>
-            can not be set to false.
+            cannot be set to false.
           </i>
         </td>
         <td>
@@ -962,9 +962,9 @@ If no attributes are specified can-fly defaults to true.
 
 ```xml
 <kit id="fly">
-    <fly/>                  <!-- Allow player to fly -->
-    <fly can-fly="false"/>  <!-- Don't allow player to fly -->
-    <fly flying="true"/>    <!-- Make the player fly right away -->
-    <fly flying="false"/>   <!-- Make the player stop flying right away -->
+    <fly/>                 <!-- Allow player to fly -->
+    <fly can-fly="false"/> <!-- Don't allow player to fly -->
+    <fly flying="true"/>   <!-- Make the player fly right away -->
+    <fly flying="false"/>  <!-- Make the player stop flying right away -->
 </kit>
 ```

--- a/docs/modules/gear/repair-remove-keep.mdx
+++ b/docs/modules/gear/repair-remove-keep.mdx
@@ -175,7 +175,7 @@ _Example_
 
 ### Armor Keep
 
-Similar to `<itemkeep>` except that the specified items are only kept if they are equipped in an armor slot.
+Similar to `<itemkeep>`, except that the specified items are only kept if they are equipped in an armor slot.
 
 <div className="table-container">
   <table>

--- a/docs/modules/gear/shops.mdx
+++ b/docs/modules/gear/shops.mdx
@@ -4,9 +4,9 @@ title: Shops
 ---
 
 The shops module is an easy way to add shop functionality to a map with a GUI interface.
-Players interact with mobs (like Villagers) which are shopkeepers which they can buy items using currencies.
+Players interact with mobs, such as Villagers, which are shopkeepers where they can buy items using currencies.
 Shops have categories of items, and each category can store up to 28 unique items.
-Players can also buy a kit instead of individual items, or use muiltiple currencies to purchase items.
+Players can also buy a kit, instead of individual items, or use muiltiple currencies to purchase items.
 
 #### Shop Element
 
@@ -47,7 +47,7 @@ Players can also buy a kit instead of individual items, or use muiltiple currenc
   </table>
 </div>
 
-### Shop Elements
+### Shop Sub-Elements
 
 <div className="table-container">
   <table>
@@ -102,7 +102,7 @@ Players can also buy a kit instead of individual items, or use muiltiple currenc
         </td>
         <td>
           <span className="badge badge--danger">Required</span>
-          The ID for the shop.
+          Unique identifier used to reference this shop from other places in the XML.
         </td>
         <td>
           <span className="badge badge--primary">String</span>
@@ -112,11 +112,9 @@ Players can also buy a kit instead of individual items, or use muiltiple currenc
         <td>
           <label>{`name`}</label>
         </td>
-        <td>The name for the in-game shop.</td>
+        <td>The display name for the shop.</td>
         <td>
-          <a href="/docs/reference/misc/formatting#chatColors">
-            Chat Color Name
-          </a>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
       </tr>
     </tbody>
@@ -141,7 +139,7 @@ Players can also buy a kit instead of individual items, or use muiltiple currenc
         </td>
         <td>
           <span className="badge badge--danger">Required</span>
-          The ID for the category.
+          Unique identifier used to reference this category from other places in the XML.
         </td>
         <td>
           <span className="badge badge--primary">String</span>
@@ -151,18 +149,16 @@ Players can also buy a kit instead of individual items, or use muiltiple currenc
         <td>
           <label>{`name`}</label>
         </td>
-        <td>The name for the in-game category.</td>
+        <td>The display name for the category.</td>
         <td>
-          <a href="/docs/reference/misc/formatting#chatColors">
-            Chat Color Name
-          </a>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
       </tr>
       <tr>
         <td>
           <label>{`material`}</label>
         </td>
-        <td>The item to display for the category</td>
+        <td>The item to display as an icon for the category</td>
         <td>
           <a href="/docs/reference/items/inventory#material_matchers">
             Material Name
@@ -212,7 +208,7 @@ Items can be purchased with multiple currencies using the `<payment>` tag.
         <td>
           <label>{`kit`}</label>
         </td>
-        <td>The kit to give to the player</td>
+        <td>The kit to give to players purchasing the item.</td>
         <td>
           <a href="/docs/modules/gear/kits">Kit</a>
         </td>
@@ -221,7 +217,7 @@ Items can be purchased with multiple currencies using the `<payment>` tag.
         <td>
           <label>{`color`}</label>
         </td>
-        <td>Changes the currency text color.</td>
+        <td>Set the currency's display text color. Can be used for associating colors with different currency tiers.</td>
         <td>
           <a href="/docs/reference/misc/formatting#chatColors">
             Chat Color Name
@@ -260,10 +256,10 @@ _Example_
 ## Shopkeepers
 
 Shopkeepers are invulnerable, unmovable entities that hold a single shop type and are spawned at match load.
-Each shop type can have an unlimited number of shopkeepers, however. There's no limitations to how many players
-can have a shop open at the same time.
+Each shop type can have an unlimited number of shopkeepers. There are no limitations to how many players
+can have a shop open simultaneously.
 
-Shopkeepers must use a single location provider, multiple inner points/regions are not allowed.
+Shopkeepers must use a single location provider, multiple inner points or regions are not allowed.
 
 ### Shopkeeper Element
 
@@ -313,6 +309,7 @@ Shopkeepers must use a single location provider, multiple inner points/regions a
         <th>Element</th>
         <th>Description</th>
         <th>Value</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
@@ -320,23 +317,23 @@ Shopkeepers must use a single location provider, multiple inner points/regions a
         <td>
           <label>{`name`}</label>
         </td>
-        <td>Name for the shopkeeper.</td>
+        <td>The display name of this shopkeeper, shown above the entity if present.</td>
         <td>
-          <a href="/docs/reference/misc/formatting#chatColors">
-            Chat Color Name
-          </a>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
+        <td></td>
       </tr>
       <tr>
         <td>
           <label>{`mob`}</label>
         </td>
         <td>
-          Mob type for shopkeeper <i>(defaults to Villager)</i>
+          The mob type for this shopkeeper to appear as.
         </td>
         <td>
           <a href="/docs/reference/entities/entity-types">Creature Type</a>
         </td>
+        <td>Villager</td>
       </tr>
       <tr>
         <td>
@@ -344,9 +341,10 @@ Shopkeepers must use a single location provider, multiple inner points/regions a
         </td>
         <td>
           <span className="badge badge--danger">Required</span>
-          The shop to use.
+          A previously defined shop to use.
         </td>
         <td>Shop ID</td>
+        <td></td>
       </tr>
     </tbody>
   </table>

--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -6,7 +6,7 @@ description: Every map XML file must contain the base map module. It contains mo
 
 Every map XML file must contain the base `<map>` module. It contains modules that specify the map name, version, objective, authors, contributors, and all other map settings. The objective is the text that players see when they join the match, and so it's important for this to be very clear, concise, and informative.
 
-The `proto=""` attribute specifies what PGM version the XML file was created for. Mapmakers should always use the latest supported proto version, which is documented in depth at [Protocol Versions](docs/modules/general/proto).
+The `proto=""` attribute specifies what PGM version the XML file was created for. Mapmakers should always use the latest supported proto version, which is documented in depth at [Protocol Versions](/docs/modules/general/proto).
 
 The maps version should follow the versioning schema `major.minor.patch`.
 
@@ -277,8 +277,7 @@ A player's name should **not** be used to credit them, instead their UUID should
         </td>
         <td>
           A major author of the map, used in
-          <label>{`<authors>`}</label>
-          <br />
+          <label>{`<authors>`}</label>.
         </td>
         <td>
           <span className="badge badge--primary">String</span>
@@ -290,7 +289,7 @@ A player's name should **not** be used to credit them, instead their UUID should
         </td>
         <td>
           A contributor to the map, used in
-          <label>{`<contributors>`}</label>
+          <label>{`<contributors>`}</label>.
         </td>
         <td>
           <span className="badge badge--primary">String</span>

--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -200,9 +200,17 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`text`}</label>
         </td>
-        <td>The text that will be sent to a player.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          The text that will be sent to a player.
+        </td>
+        <td>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td></td>
       </tr>
@@ -210,9 +218,17 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`title`}</label>
         </td>
-        <td>The title text.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          The title text.
+        </td>
+        <td>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td></td>
       </tr>
@@ -220,9 +236,17 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`subtitle`}</label>
         </td>
-        <td>The subtitle text.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          The subtitle text.
+        </td>
+        <td>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td></td>
       </tr>
@@ -230,9 +254,17 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`actionbar`}</label>
         </td>
-        <td>The text above the hotbar.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          The text above the hotbar.
+        </td>
+        <td>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td></td>
       </tr>
@@ -242,7 +274,7 @@ In the future, some features that are currently used in Kits may be transferred 
         </td>
         <td>How long the text will fade in.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
         <td>0.5 sec</td>
       </tr>
@@ -252,7 +284,7 @@ In the future, some features that are currently used in Kits may be transferred 
         </td>
         <td>How long the text will display for.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
         <td>3.5 sec</td>
       </tr>
@@ -262,7 +294,7 @@ In the future, some features that are currently used in Kits may be transferred 
         </td>
         <td>How long the text will fade out.</td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
         <td>1 sec</td>
       </tr>
@@ -379,7 +411,7 @@ In the future, some features that are currently used in Kits may be transferred 
           which will make it affected by other filters and PGM features. <em>May impact preformace for large fills.</em>
         </td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
     </tbody>
@@ -425,7 +457,7 @@ In the future, some features that are currently used in Kits may be transferred 
           item.
         </td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
       <tr>
@@ -434,7 +466,7 @@ In the future, some features that are currently used in Kits may be transferred 
         </td>
         <td>Enchantments on the old item will be applied to the new item.</td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
       <tr>
@@ -443,7 +475,7 @@ In the future, some features that are currently used in Kits may be transferred 
         </td>
         <td>Filters which entities to remove.</td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
       <tr>
@@ -482,7 +514,15 @@ trigger an Action.
         <td>
           <label>{`filter`}</label>
         </td>
-        <td>A dynamic filter that activiates the trigger.</td>
+        <td>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          A dynamic filter that activates the trigger.
+        </td>
         <td>
           <a href="/docs/modules/mechanics/filters#dynamic-filters">
             Dynamic Filter
@@ -493,7 +533,15 @@ trigger an Action.
         <td>
           <label>{`action`}</label>
         </td>
-        <td>Sets an Action.</td>
+        <td>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          Sets the action to run when the filter allows.
+        </td>
         <td>
           <a href="#action-elements">Action</a>
         </td>

--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -595,7 +595,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
         </td>
         <td>Ignore the durability of the item when matching.</td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
       <tr>
@@ -604,7 +604,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
         </td>
         <td>Ignore the metadata of the item when matching.</td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
       <tr>
@@ -613,7 +613,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
         </td>
         <td>Ignore the name of the item when matching.</td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
       <tr>
@@ -622,7 +622,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
         </td>
         <td>Ignore the enchantments of the item when matching.</td>
         <td>
-          <span className="badge badge--primary">True/False</span>
+          <span className="badge badge--primary">true/false</span>
         </td>
       </tr>
     </tbody>
@@ -941,9 +941,9 @@ This filter is commonly used in [kill rewards](/docs/modules/gear/kill-rewards),
 _Examples_
 
 ```xml
-<kill-streak min="3"/>    <!-- matches players with at least 3 kills -->
-<kill-streak max="5"/>    <!-- matches players with at most 5 kills -->
-<kill-streak count="4"/>  <!-- matches players with exactly 4 kills -->
+<kill-streak min="3"/>   <!-- matches players with at least 3 kills -->
+<kill-streak max="5"/>   <!-- matches players with at most 5 kills -->
+<kill-streak count="4"/> <!-- matches players with exactly 4 kills -->
 <kill-streak repeat="true" count="10"/>  <!-- match for every 10th kill -->
 ```
 
@@ -1119,6 +1119,18 @@ It never matches when the child filter doesn't match. This filter is a [Dynamic 
       </tr>
       <tr>
         <td>
+          <label>filter</label>
+        </td>
+        <td>
+          <span className="badge badge--danger">Required</span>
+          Filter when the countdown should be active.
+        </td>
+        <td>
+          <a href="/docs/modules/mechanics/filters#dynamic-filters">Dynamic Filter</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label>message</label>
         </td>
         <td>
@@ -1146,6 +1158,57 @@ It never matches when the child filter doesn't match. This filter is a [Dynamic 
 
 This filter starts allowing sometime after a duration the child filters start allowing.
 This filter is a [Dynamic Filter](#dynamic-filters).
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Description</th>
+        <th>Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>duration</label>
+        </td>
+        <td>
+          <span className="badge badge--danger">Required</span>
+          Length of time to be active after the child filter allows.
+        </td>
+        <td>
+          <a href="/docs/reference/misc/time-periods">Time Period</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>filter</label>
+        </td>
+        <td>
+          <span className="badge badge--danger">Required</span>
+          Filter when the after filter should be active.
+        </td>
+        <td>
+          <a href="/docs/modules/mechanics/filters#dynamic-filters">Dynamic Filter</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>message</label>
+        </td>
+        <td>
+          Optional message to display after the child filter allows.
+          Only players who match the filter can see the message.
+          If the message contains a placeholder, it will be replaced with the remaining time.
+        </td>
+        <td>
+          <span className="badge badge--primary">String</span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 ```
 <!-- Allows 15 seconds after the player gets 1st place -->
@@ -1199,6 +1262,19 @@ This filter is a [Dynamic Filter](#dynamic-filters).
       </tr>
       <tr>
         <td>
+          <label>filter</label>
+        </td>
+        <td>
+          <span className="badge badge--danger">Required</span>
+          Filter when the pulse should be active; if the filter allows, pulse will be ticking. 
+          It can be defined as a unique child element or as an attribute.
+        </td>
+        <td>
+          <a href="/docs/modules/mechanics/filters#dynamic-filters">Dynamic Filter</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <label>message</label>
         </td>
         <td>
@@ -1219,8 +1295,12 @@ This filter is a [Dynamic Filter](#dynamic-filters).
     <!-- Pulses activation for 15 seconds in a 60 second time period -->
     <!-- ie. on for 15 seconds, off for 45 seconds -->
     <!-- Filter turns off if condition doesn't meet after 60 seconds -->
-    <pulse id="pulse-filter" period="60s" duration="15s">
-        <filter id="second-filter"/>
+    <pulse id="pulse-filter" period="60s" duration="15s" filter="second-filter"/>
+
+    <!-- Pulse activates for 20 seconds in a 40 second time period -->
+    <!-- With the inner filter, it is always active until the match ends -->
+    <pulse id="other-pulse" period="40s" duration="20s">
+        <match-running/>
     </pulse>
 </filters>
 ```
@@ -1275,7 +1355,7 @@ The child filter can be omitted, in which case all players in the match will be 
         <td>
           <label>min</label>
         </td>
-        <td>Minimum player count</td>
+        <td>Minimum player count.</td>
         <td>
           <span className="badge badge--primary">Number</span>
         </td>
@@ -1285,7 +1365,7 @@ The child filter can be omitted, in which case all players in the match will be 
         <td>
           <label>max</label>
         </td>
-        <td>Maximum player count</td>
+        <td>Maximum player count.</td>
         <td>
           <span className="badge badge--primary">Number</span>
         </td>
@@ -1310,6 +1390,20 @@ The child filter can be omitted, in which case all players in the match will be 
           <span className="badge badge--primary">true/false</span>
         </td>
         <td>false</td>
+      </tr>
+      <tr>
+        <td>
+          <label>filter</label>
+        </td>
+        <td>
+          Filter when players are counted.
+        </td>
+        <td>
+          <a href="/docs/modules/mechanics/filters#dynamic-filters">Dynamic Filter</a>
+        </td>
+        <td>
+          <label>&lt;always&#47;&gt;</label>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/docs/modules/mechanics/lanes.mdx
+++ b/docs/modules/mechanics/lanes.mdx
@@ -3,7 +3,7 @@ id: lanes
 title: Lanes
 ---
 
-Lanes are used in Race for Wool (RFW) style maps with two parallel lanes for the teams. They prevent players from leaving their team's lane and entering the enemies.
+Lanes are used in Race for Wool (RFW) style maps with two parallel lanes for the teams. They prevent players from leaving their team's lane and entering the enemies' lane.
 
 #### Lanes Element
 

--- a/docs/modules/mechanics/variables.mdx
+++ b/docs/modules/mechanics/variables.mdx
@@ -63,7 +63,7 @@ You can define as many variables as you want, and all variables must have a scop
         <td>
           <label>{`id`}</label>
         </td>
-        <td>The ID for the variable.</td>
+        <td>Unique identifier used to reference this variable from other places in the XML.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>

--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -618,17 +618,17 @@ Other uses of control points include unlocking an area of the map using objectiv
 The capture rule defines the logic used to decide which team is in control of the point.
 Values for `capture-rule` can be one of the following:
 
-- `exclusive` The team must be the only team with players on the control point. (default)
-- `majority` The team must have more players on the control point than all other teams combined.
-- `lead` The team must have more players on the control point than any other single team.
+- `exclusive` &#8212; The team must be the only team with players on the control point. (default)
+- `majority` &#8212; The team must have more players on the control point than all other teams combined.
+- `lead` &#8212; The team must have more players on the control point than any other single team.
 
 Players who match either `capture-filter` or `player-filter` are counted when calculating the `capture-rule`.
-Players who don't match either filter cannot affect the control point at all.
+Players who do not match either filter cannot affect the control point at all.
 
 ### Control Point Regions
 
-Capture progress is displayed inside the defined `<progress>` region using the dominating teams color.
-After a control point is captured the `<captured>` region is also filled with that color.
+Capture progress is displayed inside the defined `<progress>` region using the dominating team's color.
+After a control point is captured, the `<captured>` region is also filled with that color.
 The progress and captured regions must be bounded regions,
 e.g. cylinders & cuboids will work, circles and squares will not.
 Only the default visual materials or materials defined in `visual-materials` will be modified
@@ -646,7 +646,7 @@ KotH is a gamemode in which you capture and hold a hill to collect points.
 The first team to reach a preset amount of points wins.
 
 KotH maps use control points to define hills.
-Instead of being called `<control-points>` they are called `<hills>` and must be defined inside a main `<king>` element.
+Instead of being called `<control-points>`, they are called `<hills>` and must be defined inside a main `<king>` element.
 The main difference between hills and control points is what their default values are.
 Default values for `time-multiplier`, `show-progress`, `neutral-state`,
 `incremental` and `permanent` differ between `<control-point>` and `<hill>`.

--- a/docs/modules/objectives/ctf.mdx
+++ b/docs/modules/objectives/ctf.mdx
@@ -3,7 +3,7 @@ id: ctf
 title: Capture the Flag
 ---
 
-Flags are [banners](https://minecraft.fandom.com/wiki/Banner) that can be picked up and carried by players, and captured in designated regions.
+Flags are [banners](https://minecraft.wiki/w/Banner) that can be picked up and carried by players, and captured in designated regions.
 They are highly configurable and can be used to implement a wide variety of gamemodes.
 
 To define a flag's appearance, a standing-banner must be manually placed by the map creator, at the flag's initial location in the map.
@@ -331,7 +331,7 @@ Filters can be used to control who can pickup/capture the flag and when.
           carrying the flag, return it to your base!"
         </td>
         <td>
-          <span className="badge badge--primary">String</span>
+          <span className="badge badge--primary">Formatted Text</span>
         </td>
         <td />
       </tr>

--- a/docs/modules/objectives/payload.mdx
+++ b/docs/modules/objectives/payload.mdx
@@ -15,8 +15,8 @@ This gamemode is entirely based off of [Control Points](/docs/modules/objectives
 so it currently supports everything that a control point supports.
 
 :::caution
-This gamemode is experimental and must be enabled for playtesting. In its
-current state, Payload only properly supports Attack/Defend type payload.
+This gamemode was introduced in PGM version `0.14`, therefore it is experimental and must be enabled for playtesting. 
+In its current state, Payload only properly supports Attack/Defend type payload.
 All documentation here is subject to rapid change.
 :::
 

--- a/docs/reference/items/attributes.mdx
+++ b/docs/reference/items/attributes.mdx
@@ -122,4 +122,4 @@ Players or mobs carrying or wearing items with these attributes will have the ef
   </table>
 </div>
 
-Incomplete list, copied from: [Minecraft Wiki Attributes](https://minecraft.fandom.com/wiki/Attribute).
+Incomplete list, copied from: [Minecraft Wiki Attributes](https://minecraft.wiki/w/Attribute).

--- a/docs/reference/items/enchantments.mdx
+++ b/docs/reference/items/enchantments.mdx
@@ -3,7 +3,7 @@ id: enchantments
 title: Enchantments
 ---
 
-Enchantments can be referenced by their Bukkit or [Minecraft](https://minecraft.fandom.com/wiki/Java_Edition_data_values/Pre-flattening#Enchantment_IDs) name.
+Enchantments can be referenced by their Bukkit or [Minecraft](https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Enchantment_IDs) name.
 Bukkit enchantment names are not case sensitive and a space can be used instead of an underscore.
 
 :::note

--- a/docs/reference/items/inventory.mdx
+++ b/docs/reference/items/inventory.mdx
@@ -1601,7 +1601,7 @@ Use `~armor`, `~block`, `~food`, `~flower`, `~redstone` etc. to filter by tags.
   <tr>
     <td>99</td>
     <td>
-      <a href="https://minecraft.fandom.com/wiki/Mushroom_Block#ID">
+      <a href="https://minecraft.wiki/w/Mushroom_Block#ID">
         <i className="fa fa-fw fa-external-link-square"></i>
       </a>
     </td>
@@ -1613,7 +1613,7 @@ Use `~armor`, `~block`, `~food`, `~flower`, `~redstone` etc. to filter by tags.
   <tr>
     <td>100</td>
     <td>
-      <a href="https://minecraft.fandom.com/wiki/Mushroom_Block#ID">
+      <a href="https://minecraft.wiki/w/Mushroom_Block#ID">
         <i className="fa fa-fw fa-external-link-square"></i>
       </a>
     </td>
@@ -4219,7 +4219,7 @@ Use `~armor`, `~block`, `~food`, `~flower`, `~redstone` etc. to filter by tags.
     <td className="data">50</td>
     <td>
       <label>MONSTER_EGG</label> NBT data is used to specify the mob:
-      <a href="https://minecraft.fandom.com/wiki/Spawn_Egg#Data_values">
+      <a href="https://minecraft.wiki/w/Spawn_Egg#Data_values">
         Spawn egg, Data Values
       </a>
     </td>

--- a/docs/reference/misc/time-periods.mdx
+++ b/docs/reference/misc/time-periods.mdx
@@ -49,4 +49,7 @@ _Examples_
 ```xml
 <!-- 5 minutes -->
 <time>5m</time>
+
+<!-- Combine multiple units for a more specific timing -->
+<time>8m20s</time> <!-- Identical to 500s -->
 ```


### PR DESCRIPTION
This pull request adds some missing information concerning the `pulse`, `countdown`, `after`, and `players` filter. Additionally, I corrected some information regarding Ender chests and relabeled the values for some items (formatted message instead of strings, etc.) and some editorial changes.