### PR TITLE
Readd documentation for lootables

### DIFF
--- a/docs/modules/gear/lootables.mdx
+++ b/docs/modules/gear/lootables.mdx
@@ -1,0 +1,436 @@
+---
+id: lootables
+title: Lootables
+---
+
+Lootables are chests or other containers that generate their contents based on custom rules and probabilities.
+They can optionally refill themselves on a schedule, or in response to dynamic filters.
+
+<div className="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th>Lootables Element</th>
+            <th>Description</th>
+            <th>Value/Children</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>{`<lootables> </lootables>`}</label>
+            </td>
+            <td />
+            <td />
+        </tr>
+        <tr>
+            <th>Sub-elements</th>
+            <th />
+            <th />
+        </tr>
+        <tr>
+            <td>
+                <label>{`<loot>`}</label>
+            </td>
+            <td>A generated set of items</td>
+            <td>
+                <span className="badge badge--secondary">Loot Sub-elements</span>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label>{`<fill>`}</label>
+            </td>
+            <td>Configuration for filling containers with loot</td>
+            <td>
+                <span className="badge badge--secondary">Fill Sub-elements</span>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+### Loot
+
+The `<loot>` element defines a generated set of items, using literal `<item>` elements,
+    and operations for choosing them.
+
+<div className="table-container" style={{ marginBottom: "30px" }}>
+    <table>
+        <thead>
+        <tr>
+            <th>Loot Element</th>
+            <th>Description</th>
+            <th>Value/Children</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>{`<loot>`}</label>
+            </td>
+            <td>A generated set of items</td>
+            <td>
+                <span className="badge badge--secondary">Loot Sub-elements</span>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<div className="table-container" style={{ marginBottom: "30px" }}>
+    <table>
+        <thead>
+        <tr>
+            <th>Loot Attributes</th>
+            <th>Description</th>
+            <th>Value</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>id</label>
+            </td>
+            <td>Unique identifier used to reference this loot elsewhere</td>
+            <td>
+                <span className="badge badge--primary">String</span>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<div className="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th style={{ minWidth: "200px" }}>Loot Sub-elements</th>
+            <th>Description</th>
+            <th>Type</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>{`<item>`}</label>
+            </td>
+            <td>
+                An item to include in the loot. This can be any type of item element,
+                and can have any item attributes.
+            </td>
+            <td>
+                <a href="/modules/items">Item</a>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label>{`<any>`}</label>
+            </td>
+            <td>
+                <a className="left-ref-link" href="#any">
+                    <i className="fa fa-chevron-down"></i>
+                </a>
+                Random selection of children
+            </td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>
+                <label>{`<maybe>`}</label>
+            </td>
+            <td>Include child conditionally based on a filter</td>
+            <td />
+        </tr>
+        <tr>
+            <td>
+                <label>{`<all>`}</label>
+            </td>
+            <td>Include all children</td>
+             <td />
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+#### Random Selection
+
+The `<any>` element makes a random selection from any number of child elements.
+    Its children can be `<option>` elements, or any other `<loot>` sub-element.
+
+<div className="table-container" style={{ marginBottom: "30px" }}>
+    <table>
+        <thead>
+        <tr>
+            <th style={{ minWidth: "150px" }}>Any Attributes</th>
+            <th>Description</th>
+            <th>Value</th>
+            <th>Default</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>count</label>
+            </td>
+            <td>Number of child elements to choose</td>
+            <td>
+                <span className="badge badge--primary">Numeric Range</span>
+            </td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>
+                <label>unique</label>
+            </td>
+            <td>
+                <label>true</label> if each child can only be chosen once.
+                <br />
+                <label>false</label> to allow a child to be chosen multiple times.
+            </td>
+            <td>
+                <span className="badge badge--primary">true/false</span>
+            </td>
+            <td>true</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<div className="table-container" style={{ marginBottom: "30px" }}>
+    <table>
+        <thead>
+        <tr>
+            <th>Any Sub-elements</th>
+            <th>Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>{`<option>`}</label>
+            </td>
+            <td>A single option for the random selection</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<div className="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th style={{ minWidth: "150px" }}>Option Attributes</th>
+            <th>Description</th>
+            <th>Value</th>
+            <th>Default</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>weight</label>
+            </td>
+            <td>Weight of this option relative to all others</td>
+            <td>
+                <span className="badge badge--primary">Number</span>
+            </td>
+            <td>1</td>
+        </tr>
+        <tr>
+            <td>
+                <label>filter</label>
+            </td>
+            <td>Filter used to decide the eligibility of this option</td>
+            <td>
+                <span className="badge badge--primary">Filter</span>
+            </td>
+            <td>
+                <label>always</label>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+#### Conditional Inclusion
+
+The `<maybe>` element includes its child elements only if the specified filter matches.
+    The filter is matched against the first player to access the loot.
+
+<div className="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th style={{ minWidth: "150px" }}>Maybe Attributes</th>
+            <th>Description</th>
+            <th>Value</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>filter</label>
+            </td>
+            <td>Filter used to decide inclusion of children</td>
+            <td>
+                <a href="/modules/filters">Filter</a>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+### Fill
+
+The `<fill>` element fills containers with generated loot.
+    It will fill **anything** that has an inventory, and matches its `filter` property.
+    This can include chests, dispensers, storage minecarts, or any other container block or entity.
+    It will fill containers regardless of where they came from, so if you don't want player-placed
+chests to be filled, then you will have to prevent that somehow.
+
+<div className="table-container" style={{ marginBottom: "30px" }}>
+    <table>
+        <thead>
+        <tr>
+            <th>Fill Element</th>
+            <th>Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>{`<fill>`}</label>
+            </td>
+            <td>Automatically fills containers with loot</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<div className="table-container">
+    <table>
+        <thead>
+        <tr>
+            <th>Fill Attributes</th>
+            <th>Description</th>
+            <th>Value</th>
+            <th>Default</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>
+                <label>loot</label>
+            </td>
+            <td>Loot to fill containers with</td>
+            <td>
+                <span className="badge badge--primary">Loot</span>
+            </td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>
+                <label>filter</label>
+            </td>
+            <td>Selects which blocks/entities to fill</td>
+            <td>
+                <span className="badge badge--primary">Filter</span>
+            </td>
+            <td>
+                <label>always</label>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label>refill-trigger</label>
+            </td>
+            <td>Optional dynamic filter that causes containers to be refilled</td>
+            <td>
+                <span className="badge badge--primary">Dynamic Filter</span>
+            </td>
+            <td />
+        </tr>
+        <tr>
+            <td>
+                <label>refill-interval</label>
+            </td>
+            <td>Time to refill containers after they are first accessed</td>
+            <td>
+                <span className="badge badge--primary">Time Period</span>
+            </td>
+            <td>oo (never)</td>
+        </tr>
+        <tr>
+            <td>
+                <label>refill-clear</label>
+            </td>
+            <td>Whether to clear containers before refilling them</td>
+            <td>
+                <span className="badge badge--primary">true/false</span>
+            </td>
+            <td>true</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+_Example_
+
+```xml
+<lootables>
+    <!-- Define a procedural list of loot -->
+    <!-- Can be different every time it is used -->
+    <!-- All operators can be composed within each other -->
+    <loot id="stuff">
+        <!-- Always include these items -->
+        <item material="stone sword"/>
+        <item material="bow"/>
+        <!-- Include if filter matches opener of the container -->
+        <maybe filter="red-team">
+            <item material="stained clay" damage="14" amount="64"/>
+            <item material="leather helmet" color="#f00"/>
+        </maybe>
+
+        <!-- Choose one element at random -->
+        <any>
+            <item material="stone" damage="1"/>
+            <item material="stone" damage="2"/>
+            <item material="stone" damage="3"/>
+        </any>
+
+        <!-- Weighted choice -->
+        <any>
+            <option weight="5">
+                <item material="cookie"/>
+            </option>
+            <option weight="3">
+                <item material="bread"/>
+            </option>
+            <option weight="1">
+                <item material="golden apple"/>
+            </option>
+        </any>
+
+        <!-- Choose any two unique elements (unique="false" to allow duplicates) -->
+        <any count="2">
+            ...
+        </any>
+
+        <!-- Choose between 3 and 5 unique elements -->
+        <any count="3..5">
+            ...
+        </any>
+    </loot>
+
+    <!-- Define inventories to refill -->
+    <!-- Filling always happens when a player opens the inventory -->
+    <!-- Any block or entity that has an inventory (and matches the filter) will be filled -->
+    <fill loot="stuff"          <!-- Loot to fill inventory with -->
+          filter="chests"       <!-- Inventories to fill (blocks or entities) -->
+          refill-interval="3s"  <!-- Minimum interval between refills (default +inf) -->
+          refill-trigger="..."  <!-- Dynamic filter to trigger refill (default none) -->
+          refill-clear="true"   <!-- Clear inventory before refilling (default true) -->
+    />
+</lootables>
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -69,7 +69,8 @@ const sidebars = {
       "modules/gear/repair-remove-keep",
       "modules/gear/projectiles",
       "modules/gear/tnt",
-      "modules/gear/kill-rewards"],
+      "modules/gear/kill-rewards",
+      "modules/gear/lootables"],
     },
     {
       type: 'category',


### PR DESCRIPTION
Readds lootables documentation removed in this commit https://github.com/PGMDev/PGM/commit/c92db582298f0dd61e794d67c8a68a74871aa113

The PR https://github.com/PGMDev/PGM/pull/1044 for readding lootables says that the syntax is the same, so the documentation is essentially the same as what was originally removed.