### PR TITLE
Update Actions & Trigger, Dye Colors, & add Sounds

### DIFF
--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -25,7 +25,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`<action> </action>`}</label>
         </td>
-        <td>A single Action.</td>
+        <td>A group of actions running in a sequence.</td>
       </tr>
       <tr>
         <td>
@@ -38,6 +38,12 @@ In the future, some features that are currently used in Kits may be transferred 
           <label>{`<message/>`}</label>
         </td>
         <td>A message that is sent to the player.</td>
+      </tr>
+      <tr>
+        <td>
+          <label>{`<sound/>`}</label>
+        </td>
+        <td>A sound that is played for the player.</td>
       </tr>
       <tr>
         <td>
@@ -96,7 +102,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`id`}</label>
         </td>
-        <td>An ID.</td>
+        <td>Unique identifier used to reference this action from other places in the XML.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -105,7 +111,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`scope`}</label>
         </td>
-        <td>Runs the filter against a certain query.</td>
+        <td>Sets the scope target an action should operate against.</td>
         <td>
           <label>{`player`}</label>, <label>{`team`}</label>, <label>{`match`}</label>
         </td>
@@ -156,7 +162,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`id`}</label>
         </td>
-        <td>An ID.</td>
+        <td>Unique identifier used to reference this switch-scope from other places in the XML.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -165,7 +171,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`inner`}</label>
         </td>
-        <td>Runs the filter against a new query.</td>
+        <td>Specify the scope of the inner action.</td>
         <td>
           <label>{`player`}</label>, <label>{`team`}</label>, <label>{`match`}</label>
         </td>
@@ -174,7 +180,12 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`outer`}</label>
         </td>
-        <td>The previously defined query.</td>
+        <td>Specify the scope outside of an action.
+        <br />
+        <em>
+          In some cases, this can be omitted as PGM will automatically infer the outer scope.
+        </em>
+        </td>
         <td>
           <label>{`player`}</label>, <label>{`team`}</label>, <label>{`match`}</label>
         </td>
@@ -207,43 +218,7 @@ In the future, some features that are currently used in Kits may be transferred 
           >
             Property
           </span>
-          The text that will be sent to a player.
-        </td>
-        <td>
-          <span className="badge badge--primary">Formatted Text</span>
-        </td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>
-          <label>{`title`}</label>
-        </td>
-        <td>
-          <span
-            className="badge badge--secondary"
-            title="Can be either this attribute or a sub-element."
-          >
-            Property
-          </span>
-          The title text.
-        </td>
-        <td>
-          <span className="badge badge--primary">Formatted Text</span>
-        </td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>
-          <label>{`subtitle`}</label>
-        </td>
-        <td>
-          <span
-            className="badge badge--secondary"
-            title="Can be either this attribute or a sub-element."
-          >
-            Property
-          </span>
-          The subtitle text.
+          The text that will be sent in the chat to a player.
         </td>
         <td>
           <span className="badge badge--primary">Formatted Text</span>
@@ -270,9 +245,45 @@ In the future, some features that are currently used in Kits may be transferred 
       </tr>
       <tr>
         <td>
+          <label>{`title`}</label>
+        </td>
+        <td>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          The title text that will appear in the center of the player's screen.
+        </td>
+        <td>
+          <span className="badge badge--primary">Formatted Text</span>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>{`subtitle`}</label>
+        </td>
+        <td>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          The subtitle text that will appear below the title text.
+        </td>
+        <td>
+          <span className="badge badge--primary">Formatted Text</span>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
           <label>{`fade-in`}</label>
         </td>
-        <td>How long the text will fade in.</td>
+        <td>How long the title and subtitle text will fade in.</td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
@@ -282,7 +293,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`stay`}</label>
         </td>
-        <td>How long the text will display for.</td>
+        <td>How long the title and subtitle text will display for.</td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
@@ -292,11 +303,70 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`fade-out`}</label>
         </td>
-        <td>How long the text will fade out.</td>
+        <td>How long the title and subtitle text will fade out.</td>
         <td>
           <a href="/docs/reference/misc/time-periods">Time Period</a>
         </td>
         <td>1 sec</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Sound Attributes
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Description</th>
+        <th>Value</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <label>{`preset`}</label>
+        </td>
+        <td>Allows you to reuse a pre-existing sound with predefined volume and pitch.</td>
+        <td>
+          <a href="/docs/reference/misc/sounds">Sound Presets</a>
+        </td>
+        <td>
+          <label>CUSTOM</label>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <label>{`key`}</label>
+        </td>
+        <td>The sound type that will be played for a player.</td>
+        <td>
+          <a href="/docs/reference/misc/sounds#sound-keys">Sound Keys</a>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          <label>{`volume`}</label>
+        </td>
+        <td>How loud or quiet a sound should be.</td>
+        <td>
+          <span className="badge badge--primary">Number</span>
+        </td>
+        <td>1.0</td>
+      </tr>
+      <tr>
+        <td>
+          <label>{`pitch`}</label>
+        </td>
+        <td>The tone of the sound.</td>
+        <td>
+          <span className="badge badge--primary">Number</span>
+        </td>
+        <td>1.0</td>
       </tr>
     </tbody>
   </table>
@@ -318,7 +388,10 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`var`}</label>
         </td>
-        <td><span className="badge badge--danger">Required</span> The variable to update.</td>
+        <td>
+          <span className="badge badge--danger">Required</span> 
+          The variable to update.
+        </td>
         <td>
           <a href="/docs/modules/mechanics/variables">Variable</a>
         </td>
@@ -327,7 +400,9 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`value`}</label>
         </td>
-        <td><span className="badge badge--danger">Required</span> Sets a new value for the variable.</td>
+        <td>
+          <span className="badge badge--danger">Required</span> 
+          Sets a new value for the variable.</td>
         <td>
           <span className="badge badge--primary">String</span>
         </td>
@@ -370,6 +445,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <th>Attribute</th>
         <th>Description</th>
         <th>Value</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
@@ -377,10 +453,21 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <label>{`region`}</label>
         </td>
-        <td>The region to fill in.</td>
+        <td>
+          <span
+            className="badge badge--secondary"
+            title="Can be either this attribute or a sub-element."
+          >
+            Property
+          </span>
+          <span className="badge badge--danger">Required</span>
+          The region to fill in. Multiple regions will be treated
+          as an union.
+        </td>
         <td>
           <a href="/docs/modules/mechanics/Regions">Region</a>
         </td>
+        <td></td>
       </tr>
       <tr>
         <td>
@@ -392,6 +479,7 @@ In the future, some features that are currently used in Kits may be transferred 
             Single Material Pattern
           </a>
         </td>
+        <td></td>
       </tr>
       <tr>
         <td>
@@ -401,6 +489,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <a href="/docs/modules/mechanics/filters">Filter</a>
         </td>
+        <td></td>
       </tr>
       <tr>
         <td>
@@ -413,6 +502,7 @@ In the future, some features that are currently used in Kits may be transferred 
         <td>
           <span className="badge badge--primary">true/false</span>
         </td>
+        <td>false</td>
       </tr>
     </tbody>
   </table>
@@ -550,7 +640,7 @@ trigger an Action.
         <td>
           <label>{`scope`}</label>
         </td>
-        <td>Runs the filter against a certain query.</td>
+        <td>Specify the scope for which to test the filter.</td>
         <td>
           <label>{`player`}</label>, <label>{`team`}</label>, <label>{`match`}</label>
         </td>
@@ -575,7 +665,7 @@ _Example_
         <!-- Gives the player who activated the trigger a diamond -->
         <message text="You've been given a diamond!"/>
         <kit>
-            <item>diamond</item>
+            <item material="diamond"/>
         </kit>
         <!-- Sends a message to the player's team -->
         <switch-scope outer="player" inner="team">
@@ -602,29 +692,29 @@ in order to use `/action`. See [Commands](/docs/commands/main) for more details.
 
 ```
 <actions>
-  <!-- Moderator uses "/action trigger start-blitz" to start this Action -->
-  <action id="start-blitz" expose="true" scope="match">
-    <!-- Sends notification to chat -->
-    <message text="Blitz mode has been enabled!"/>
-    <!-- Sets blitz_enabled to 1 -->
-    <set var="blitz_enabled" value="1"/>
-  </action>
+    <!-- Moderator uses "/action trigger start-blitz" to start this Action -->
+    <action id="start-blitz" expose="true" scope="match">
+        <!-- Sends notification to chat -->
+        <message text="Blitz mode has been enabled!"/>
+        <!-- Sets blitz_enabled to 1 -->
+        <set var="blitz_enabled" value="1"/>
+    </action>
 
-  <!-- Moderator uses "/action trigger end-blitz" to start this Action -->
-  <action id="end-blitz" expose="true" scope="match">
-    <message text="Blitz mode has been disabled!"/>
-    <set var="blitz_enabled" value="0"/>
-  </action>
+    <!-- Moderator uses "/action trigger end-blitz" to start this Action -->
+    <action id="end-blitz" expose="true" scope="match">
+        <message text="Blitz mode has been disabled!"/>
+        <set var="blitz_enabled" value="0"/>
+    </action>
 </actions>
 <!-- Creates the blitz_enabled variable -->
 <variables>
-  <variable id="blitz_enabled" scope="match"/>
+    <variable id="blitz_enabled" scope="match"/>
 </variables>
 <blitz>
   <!-- Matches for a condition where a player loses a life -->
   <filter>
-    <!-- If a player dies when blitz_enabled is 1, they lose a life -->
-    <variable var="blitz_enabled">1</variable>
+      <!-- If a player dies when blitz_enabled is 1, they lose a life -->
+      <variable var="blitz_enabled">1</variable>
   </filter>
 </blitz>
 ```

--- a/docs/reference/misc/colors.mdx
+++ b/docs/reference/misc/colors.mdx
@@ -3,20 +3,31 @@ id: colors
 title: Dye Colors
 ---
 
-Dye color names are used to define a wools color on [CTW](/docs/modules/objectives/ctw) maps and the dyes hex color can be used to color armor. Teams are created with the chat color names defined in [formatting](/docs/reference/misc/formatting#chat-colors).
+Dye color names are used to define a wool's color on [Capture the Wool (CTW)](/docs/modules/objectives/ctw) and a flag's color on [Capture the Flag (CTF)](/docs/modules/objectives/ctf) maps.
+The dye's HEX color can be used to color leather armor.
+Teams are created with the chat color names defined in [Text Formatting](/docs/reference/misc/formatting#chat-colors).
+However, you can use the <a href="/docs/modules/format/teams#team-attributes">`dye-color` attribute</a> to force a specific dye color for an individual team.
 
 <div className="table-container">
   <table>
     <thead>
       <tr>
         <th>Color Name</th>
-        <th>Hex Color</th>
-        <th>Hex Firework Color</th>
+        <th style={{ width: "60px" }}>
+          <label>team-color</label>
+          Damage Value
+        </th>
+        <th>Armor HEX Color</th>
+        <th>Firework HEX Color</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>WHITE</td>
+        <td>
+          <span style={{color: "#E4E4E4"}}>&#9632;</span>
+          0
+        </td>
         <td>
           <label>FFFFFF</label>
         </td>
@@ -27,6 +38,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>ORANGE</td>
         <td>
+          <span style={{color: "#EA7e35"}}>&#9632;</span>
+          1
+        </td>
+        <td>
           <label>D87F33</label>
         </td>
         <td>
@@ -35,6 +50,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>MAGENTA</td>
+        <td>
+          <span style={{color: "#BE49C9"}}>&#9632;</span>
+          2
+        </td>
         <td>
           <label>B24CD8</label>
         </td>
@@ -45,6 +64,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>LIGHT_BLUE</td>
         <td>
+          <span style={{color: "#6387D2"}}>&#9632;</span>
+          3
+        </td>
+        <td>
           <label>6699D8</label>
         </td>
         <td>
@@ -53,6 +76,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>YELLOW</td>
+        <td>
+          <span style={{color: "#C2b51C"}}>&#9632;</span>
+          4
+        </td>
         <td>
           <label>E5E533</label>
         </td>
@@ -63,6 +90,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>LIME</td>
         <td>
+          <span style={{color: "#39BA2E"}}>&#9632;</span>
+          5
+        </td>
+        <td>
           <label>7FCC19</label>
         </td>
         <td>
@@ -71,6 +102,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>PINK</td>
+        <td>
+          <span style={{color: "#D98199"}}>&#9632;</span>
+          6
+        </td>
         <td>
           <label>F27FA5</label>
         </td>
@@ -81,6 +116,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>GRAY</td>
         <td>
+          <span style={{color: "#414141"}}>&#9632;</span>
+          7
+        </td>
+        <td>
           <label>4C4C4C</label>
         </td>
         <td>
@@ -89,6 +128,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>SILVER</td>
+        <td>
+          <span style={{color: "#A0A7A7"}}>&#9632;</span>
+          8
+        </td>
         <td>
           <label>999999</label>
         </td>
@@ -99,6 +142,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>CYAN</td>
         <td>
+          <span style={{color: "#267191"}}>&#9632;</span>
+          9
+        </td>
+        <td>
           <label>4C7F99</label>
         </td>
         <td>
@@ -107,6 +154,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>PURPLE</td>
+        <td>
+          <span style={{color: "#7E34BF"}}>&#9632;</span>
+          10
+        </td>
         <td>
           <label>7F3FB2</label>
         </td>
@@ -117,6 +168,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>BLUE</td>
         <td>
+          <span style={{color: "#253193"}}>&#9632;</span>
+          11
+        </td>
+        <td>
           <label>334CB2</label>
         </td>
         <td>
@@ -125,6 +180,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>BROWN</td>
+        <td>
+          <span style={{color: "#56331C"}}>&#9632;</span>
+          12
+        </td>
         <td>
           <label>664C33</label>
         </td>
@@ -135,6 +194,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>GREEN</td>
         <td>
+          <span style={{color: "#364B18"}}>&#9632;</span>
+          13
+        </td>
+        <td>
           <label>667F33</label>
         </td>
         <td>
@@ -144,6 +207,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       <tr>
         <td>RED</td>
         <td>
+          <span style={{color: "#9E2B27"}}>&#9632;</span>
+          14
+        </td>
+        <td>
           <label>993333</label>
         </td>
         <td>
@@ -152,6 +219,10 @@ Dye color names are used to define a wools color on [CTW](/docs/modules/objectiv
       </tr>
       <tr>
         <td>BLACK</td>
+        <td>
+          <span style={{color: "#181414"}}>&#9632;</span>
+          15
+        </td>
         <td>
           <label>191919</label>
         </td>

--- a/docs/reference/misc/sounds.mdx
+++ b/docs/reference/misc/sounds.mdx
@@ -1,0 +1,164 @@
+---
+id: sounds
+title: Sound Presets
+---
+
+Sounds are used to draw a player's attention to certain events on a map. PGM comes with several preset sounds that can be quickly used for scenarios.
+It can be used in combination with other actions, as defined in [Actions &amp; Triggers](/docs/modules/mechanics/actions-triggers#sound-attributes).
+
+<div className="table-container">
+  <table>
+    <thead>
+      <tr>
+        <th>Sound Type</th>
+        <th>Description</th>
+        <th>Default Volume</th>
+        <th>Default Pitch</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>CUSTOM</td>
+        <td>
+          Note pling; fallback sound when no sound are defined.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>TIP</td>
+        <td>
+          Used for <a href="/docs/modules/information/broadcasts">Tip broadcast messages</a>.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>1.2</label>
+        </td>
+      </tr>
+      <tr>
+        <td>ALERT</td>
+        <td>
+          High-pitched note pling; used for <a href="/docs/modules/information/broadcasts">Alert broadcast messages</a>.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>2.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>PORTAL</td>
+        <td>
+          Used for <a href="/docs/modules/mechanics/portals">Portals</a>.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>SCORE</td>
+        <td>
+          Used when the player enters a <a href="/docs/modules/objectives/scoring#score-boxes">Score Box</a>.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          OBJECTIVE_FIREWORKS_FAR
+          <br />
+          OBJECTIVE_FIREWORKS_TWINKLE
+        </td>
+        <td>
+          Used for <a href="/docs/modules/objectives/dtm#destroyable-attributes">Destroyables</a> when <label>sparks</label> is enabled.
+        </td>
+        <td>
+          <label>0.75</label>
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>OBJECTIVE_GOOD</td>
+        <td>
+          Used when the player's team completes or captures an objective.
+        </td>
+        <td>
+          <label>0.7</label>
+        </td>
+        <td>
+          <label>2.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>OBJECTIVE_BAD</td>
+        <td>
+          Used when the enemy team completes or captures an objective.
+        </td>
+        <td>
+          <label>0.8</label>
+        </td>
+        <td>
+          <label>0.8</label>
+        </td>
+      </tr>
+      <tr>
+        <td>OBJECTIVE_MODE</td>
+        <td>
+          Used when <a href="/docs/modules/objectives/monument-modes">Monument Modes</a> are triggered.
+        </td>
+        <td>
+          <label>0.15</label>
+        </td>
+        <td>
+          <label>1.2</label>
+        </td>
+      </tr>
+      <tr>
+        <td>DEATH_OWN</td>
+        <td>
+          Used when the player or a teammate dies during a match.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+      </tr>
+      <tr>
+        <td>DEATH_OTHER</td>
+        <td>
+          Used when an enemy player dies during a match.
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+        <td>
+          <label>1.0</label>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+Copied from: [Kyori Adventure docs - Sound](https://docs.advntr.dev/sound.html)
+
+### Sound Keys
+
+A list of sound keys available in Minecraft 1.8 can be found on [Minecraft Wiki - Sounds.json](https://minecraft.wiki/w/Sounds.json/Java_Edition_values_before_1.9).

--- a/sidebars.js
+++ b/sidebars.js
@@ -97,6 +97,7 @@ const sidebars = {
       "reference/misc/formatting",
       "reference/misc/objective-names",
       "reference/misc/colors",
+      "reference/misc/sounds",
       "reference/misc/time-periods",
     ],
   },


### PR DESCRIPTION
### Actions & Triggers
* Changed descriptions on some table entries to clarify features some more
* Documented play-sound action (resolves #104)
* Fixed indentation to be 4-spaces instead of 2-spaces in example XML.

The only thing yet to be done is adding more examples to demonstrate each action. Pablo has already given me some resources to quickly put some together, however, this is the most time-consuming part for me.

### Sound Presets
Created a new page showing a list of sound presets that PGM ships with, allowing users to re-use it for a play-sound action. I've already linked to it from the new table in the Actions & Trigger page and it can be found under `Reference > Misc` from the navigation bar.

The only thing left in this area is to document all the possible sound key values in Minecraft 1.8, or at least provide a link where it'll be organized in a table similarly to PGM sound presets.

![image](https://github.com/PGMDev/Website/assets/20259871/a28743b4-0854-41f6-b4ab-39c887a001f3)


### Dye Colors
Added some description to when and where you can use dye colors in a standard map.xml file. I've also added a new column to the table to show the corresponding block damage value (which is also consistent across stained clay, stained glass block/panes, and wools) for each dye color when using the `team-color` attribute.

![image](https://github.com/PGMDev/Website/assets/20259871/2901d229-a339-48cc-b6ac-5822b6d9f803)
