### PR TITLE
Document tracking compass modules & more

### DIFF
--- a/docs/commands/community.mdx
+++ b/docs/commands/community.mdx
@@ -1,6 +1,7 @@
 ---
 id: community
 title: Community Commands
+hide_table_of_contents: true
 ---
 
 This page describes a list of commands, aliases, and permissions for [Community](https://github.com/PGMDev/Community/), a standalone plugin for managing PGM servers. 

--- a/docs/commands/events.mdx
+++ b/docs/commands/events.mdx
@@ -1,6 +1,7 @@
 ---
 id: events
 title: Events Commands
+hide_table_of_contents: true
 ---
 
 This page describes a list of commands, aliases, and permissions for the [Events](https://github.com/PGMDev/Events) plugin.

--- a/docs/commands/main.mdx
+++ b/docs/commands/main.mdx
@@ -1,6 +1,7 @@
 ---
 id: main
 title: PGM Commands
+hide_table_of_contents: true
 ---
 
 This page describes a list of PGM commands, aliases, and permissions.
@@ -13,16 +14,20 @@ Permissions are prefixed with `Permissions` (i.e. `Permissions.ADMINCHAT`).
   | `/action list` | actions list<br />actions page | Inspect variables for a player. | -q query<br />-a all | [page] | `GAMEPLAY` |
   | `/action trigger` | actions trigger | Trigger a specific action. || [action] | `GAMEPLAY` |
   | `/action untrigger` | actions untrigger | Untrigger a specific action. || [action] | `GAMEPLAY` |
+  | `/filter` || Match a filter against a player. || [filter] [target] | `DEBUG` |
   | `/mode push` || Reschedule all unconditional objective modes. || [time] | `GAMEPLAY` |
   | `/mode start` || Starts an objective mode. || [mode number] [time] | `GAMEPLAY` |
   | `/team alias` || Rename a team. || [old team name] [new team name] | `GAMEPLAY` |
   | `/timelimit` | tl | Start a time limit. | -r result (can be `default`, `objectives`, `tie`, or name of team) | [duration] [result] [overtime] [max-overtime] | `GAMEPLAY` |
-  | `/join` | play | Join the match. | -f force | [team] – defaults to random | `JOIN` |
+  | `/join` | play | Join the match. | -f force | [team] - defaults to random | `JOIN` |
   | `/team force` || Force a player onto a team. ||| `JOIN_FORCE` |
-  | `/team shuffle` || Shuffle players among the teams. || -a all -f force | `JOIN_FORCE` |
+  | `/team shuffle` || Shuffle players among the teams. | -a all<br />-f force || `JOIN_FORCE` |
   | `/leave` | obs | Leave the match. ||| `LEAVE` |
   | `/loadnewmaps` | findnewmaps<br />new<br />maps | Load new maps. | -f force || `RELOAD` |
-  | `/pgm` || Reload the configuration. ||| `RELOAD` |
+  | `/showxml` || Open a file editor with the map's XML on the server side.<br />**Note:** This command is only available for locally hosted servers with a desktop environment. || [map name] |
+  | `/pgm reload` || Reload the configuration. ||| `RELOAD` |
+  | `/pgm help` || View available PGM commands. ||| `RELOAD` |
+  | `/pgm confirm` || Execute any pending commands. ||| `RELOAD` |
   | `/ffa min` || Set the minimum players. || [reset &#124; min-players] | `RESIZE` |
   | `/ffa size` || Set the maximum players. || [reset &#124; max-players] (max-overfill) | `RESIZE` |
   | `/team min` || Set the minimum players on a team. || [team] (reset &#124; min-players) | `RESIZE` |
@@ -46,9 +51,9 @@ Permissions are prefixed with `Permissions` (i.e. `Permissions.ADMINCHAT`).
   | `/class` | selectclass<br />c<br />cl | Selects your class. |
   | `/classlist` | classes<br />listclasses<br />cls | List all available classes. |
   | `/g` | all<br />! (*do not use forward slash*) | Send a message to everyone. || [message] |
-  | `/inventory` | inv<br />vi | View a player’s inventory. |
+  | `/inventory` | inv<br />vi | View a player's inventory. |
   | `/list` | who<br />online<br />ls | View a list of online players. |
-  | `/map` | mapinfo | Show info about a map. || [map name] – defaults to current map |
+  | `/map` | mapinfo | Show info about a map. || [map name] - defaults to current map |
   | `/maps` | maplist<br />ml | List all loaded maps. | -a author<br />-t tag1,tag2<br />-n name |
   | `/match` | matchinfo | Show the match info. |
   | `/mode list` | page | List all objective modes. || [page] |

--- a/docs/modules/environment/world.mdx
+++ b/docs/modules/environment/world.mdx
@@ -6,7 +6,8 @@ description: You can use these world and terrain modules to have a finer control
 
 ### Build Height
 
-A world's maximum build height can be set using the `maxbuildheight` element. Once a player tries to build past the set maximum build height, they will be prompted with a message stating that they can not build past the playing field.
+A world's maximum build height can be set using the `maxbuildheight` element.
+Once a player tries to build past the set maximum build height, they will be prompted with a message stating that they can not build past the playing field.
 
 ```xml
 <maxbuildheight>64</maxbuildheight>
@@ -14,14 +15,15 @@ A world's maximum build height can be set using the `maxbuildheight` element. On
 
 ### Terrain
 
-A world's terrain generator can be modified to use a specific seed, world and/or whether the vanilla chunk generator is used. By default a new random seed is generated for each match, unless one is specified in the seed attribute.
+A world's terrain generator can be modified to use a specific seed, world and/or whether the vanilla chunk generator is used. 
+By default a new random seed is generated for each match, unless one is specified in the seed attribute.
 
 When using the vanilla generator, the default Minecraft terrain generator will be used instead of generating null chunks.
-The specific world generation rules such as flat worlds, etc., can be changed by editing the world's `level.dat` file with a NBT editor. The `RandomSeed` value in the level data file is not used.
+The specific world generation rules such as flat worlds, etc., can be changed by editing the world's `level.dat` file with a NBT editor.
+The `RandomSeed` value in the level data file is not used.
 
-Any chunks not in the world's `region/` folder will be generated according to the Minecraft chunk generation rules. This means that only the terrain that you have modified needs to be saved with the world.
-
-The `world=""` attribute is used to specify the sub-folder that contains the map's `region/` and `level.dat` files.
+Any chunks not in the world's `region/` folder will be generated according to the Minecraft chunk generation rules.
+This means that only the terrain that you have modified needs to be saved with the world.
 
 <div className="table-container">
   | Element | Description |
@@ -34,22 +36,18 @@ The `world=""` attribute is used to specify the sub-folder that contains the map
 <div className="table-container">
   | Attribute | Description | Value | Default |
   |---|---|---|---|
-  | `world` | The level data sub-folder to be used with this map. | <span className="badge badge--primary">Sub-folder Name</span> |
   | `vanilla` | Specify if this world is uses the vanilla or null chunk generator. | <span className="badge badge--primary">true/false</span> | false |
-  | `seed` | This world's generation seed. | <span className="badge badge--primary">String</span> |
-  | `pre-match-physics` | Allow physics events, such as water flowing, before the match starts. | <span className="badge badge--primary">true/false</span> | false |
+  | `seed` | The world's seed that determines how the world is generated. | <span className="badge badge--primary">String</span> |
+  | `environment` | The world's dimension type.<br />**Note:** Worlds with `the end` environment are not supported. | `normal`<br />`nether` | `normal` |
+  | `pre-match-physics` | <span className="badge badge--danger" title="This feature once existed, but has not been re-implemented in modern versions of PGM.">N/A</span>Allow physics events, such as water flowing, before the match starts. | <span className="badge badge--primary">true/false</span> | false |
 </div>
 
 ```xml
+<!-- Make a vanilla world with the seed 'qwerty' -->
 <terrain vanilla="true" seed="qwerty"/>
 
-<!-- Christmas world conditional -->
-<if christmas="true">
-    <terrain world="christmas"/>
-</if>
-<if christmas="false">
-    <terrain world="normal"/>
-</if>
+<!-- Make the world Nether-like. The 'region' folder must be renamed to 'DIM-1' for this to work. -->
+<terrain environment="nether"/>
 ```
 
 ### Internal Maps

--- a/docs/modules/gear/consumables.mdx
+++ b/docs/modules/gear/consumables.mdx
@@ -25,15 +25,31 @@ When consumed, these items can trigger [actions](/docs/modules/mechanics/actions
   | Attribute | Description | Value | Default |
   |---|---|---|---|
   | `id` | <span className="badge badge--danger">Required</span>Unique identifier used to reference this consumable from other places in the XML. | <span className="badge badge--primary">String</span> |
-  | `action`&#124;`kit` | <span className="badge badge--danger">Required</span>Run the specified action upon consumption. | [Action ID](/docs/modules/mechanics/actions-triggers) |
-  | `on` | <span className="badge badge--danger">Required</span>Specify how the consumable should be used.<br />**Note:** The only action currently supported is `eat`. In the future, more actions such as clicking will be supported. | `eat` |
-  | `override` | Consumable is affected by vanilla behaviors, such as giving the player potion effects.<br />*This is useful when using potion bottles and golden apples as the consumable item.* | <span className="badge badge--primary">true/false</span> | true |
+  | `action` | <span className="badge badge--danger">Required</span>Run the specified action upon consumption. | [Action ID](/docs/modules/mechanics/actions-triggers) |
+  | `on` | <span className="badge badge--danger">Required</span>Specify how the consumable should be used. | `eat`<br />`right click`<br />`left click`<br />`click` (both) |
+  | `override` | The consumable is affected by vanilla behaviors, such as giving the player potion effects.<br />*This is useful when using potion bottles and golden apples as the consumable item.* | <span className="badge badge--primary">true/false</span> | true |
+  | `consume` | PGM will consume the item once per use for the user.<br />**Note:** This attribute is ignored if the value of `on` attribute is `eat`. | <span className="badge badge--primary">true/false</span> | [*](#override--consume-behavior) |
+</div>
+
+### Override & Consume Behavior
+Some combinations of `override` and `consume` values can lead to unexpected behaviors involving either
+the user's client or PGM itself. This chart outlines the expected vanilla behavior for each configuration.
+
+<div className="table-container">
+  | Override | Consume | Vanilla Behavior | Result |
+  |---|---|---|---|
+  | `false` | `false` | No consume (e.g.: stick) | <span className="badge badge--success">Optimal</span>0 used |
+  | `false` | `false` | Consumes (e.g.: snowball) | <span className="badge badge--warning">Sub-optimal</span>1 used |
+  | `false` | `true` | No consume (e.g.: stick) | <span className="badge badge--success">Optimal</span>1 used |
+  | `false` | `true` | Consumes (e.g.: snowball) | <span className="badge badge--danger">Invalid</span>2 used |
+  | `true` | `false` | Any case | <span className="badge badge--success">Optimal</span>0 used |
+  | `true` | `true` | Any case | <span className="badge badge--success">Optimal</span>1 used |
 </div>
 
 ### Examples
 
 ```xml
-<!-- Create the consumable "template" -->
+<!-- Create the consumable "porkchop-that-says-yum" -->
 <consumables>
     <consumable id="porkchop-that-says-yum" action="say-yum" on="eat" override="false"/>
 </consumables>
@@ -50,9 +66,9 @@ When consumed, these items can trigger [actions](/docs/modules/mechanics/actions
 ```
 
 ```xml
-<!-- Create the consumable "template" -->
+<!-- Create the consumable "fast-apple" -->
 <consumables>
-    <consumable id="fast-apple" kit="speed-kit" on="eat"/>
+    <consumable id="fast-apple" action="speed-kit" on="eat"/>
 </consumables>
 <kits>
     <!-- Apply the consumable to an item -->
@@ -62,6 +78,25 @@ When consumed, these items can trigger [actions](/docs/modules/mechanics/actions
     <!-- Define the kit the consumable gives you -->
     <kit id="speed-kit">
         <effect duration="4" amplifier="10">speed</effect>
+    </kit>
+</kits>
+```
+
+```xml
+<!-- Create the consumable "heal" -->
+<!-- When the healing stick is right clicked, it is "consumed" and applies the
+heal-click action (kit) that sets the player's health back to 20 -->
+<consumables>
+    <consumable id="heal" action="heal-click" on="click" override="true" consume="true"/>
+</consumables>
+<kits>
+    <!-- Apply the consumable to an item -->
+    <kit id="spawn-kit">
+        <item material="stick" consumable="heal" name="Healing stick!"/>
+    </kit>
+    <!-- Define the kit the consumable gives you -->
+    <kit id="heal-click">
+        <health>20</health>
     </kit>
 </kits>
 ```

--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -43,7 +43,7 @@ or on the [bukkit docs - Material](https://hub.spigotmc.org/javadocs/bukkit/org/
   | `name` | The item's display name that appears when it is selected. | <span className="badge badge--primary">Formatted Text</span> |
   | `lore` | Custom text that appears when a player hovers over the item in their inventory. | <span className="badge badge--primary">Formatted Text</span> |
   | `color` | Leather armor color as a hexadecimal color. `RRGGBB`<br />*Only applies to leather armor items.* | <span className="badge badge--primary">Hex Color</span> |
-  | `team-color` | Automatically applies the team's [Dye Color](/docs/modules/format/teams#team-attributes) to colored blocks *(wool, stained glass, etc)*. | <span className="badge badge--primary">true/false</span> | false |
+  | `team-color` | Automatically applies the team's [Dye Color](/docs/modules/format/teams#team-attributes) to colored blocks *(wool, stained glass, banner, etc)*. | <span className="badge badge--primary">true/false</span> | false |
   | `grenade` | Projectile explodes on impact.<br />*Works with ender pearls, snowballs, eggs, and arrows.* | <span className="badge badge--primary">true/false</span> | false |
   | `grenade-power` | The power of the grenade explosion on impact. | <span className="badge badge--primary">Decimal</span> | 1.0 |
   | `grenade-fire` | Toggle if grenade explosion creates fire. | <span className="badge badge--primary">true/false</span> | false |

--- a/docs/modules/gear/repair-remove-keep.mdx
+++ b/docs/modules/gear/repair-remove-keep.mdx
@@ -20,7 +20,7 @@ Repairing arrows instead of removing them has the advantage of the player being 
   |---|---|
   | `<toolrepair> </toolrepair>` | A node containing all the tools that will be repaired when picked up. |
 
-  | Sub-elements | | Value/Children |
+  | Sub-elements | | Value |
   |---|---|---|
   | `<tool> </tool>` | A single tool that will be repaired, can be anything with durability. | [Material Name](/docs/reference/items/inventory#material-matchers) |
 </div>
@@ -43,7 +43,7 @@ Defines items that will be deleted when dropped on the map. Also works when item
   |---|---|
   | `<itemremove> </itemremove>` | A node containing all the items that will be removed when dropped. |
 
-  | Sub-elements | | Value/Children |
+  | Sub-elements | | Value |
   |---|---|---|
   | `<item> </item>` | The item that will be removed when dropped. | [Material Name](/docs/reference/items/inventory#material-matchers) |
 </div>
@@ -69,7 +69,7 @@ If there is a spawn kit, kept items will be given back *after* the kit is applie
   |---|---|
   | `<itemkeep> </itemkeep>` | A node containing all the items kept when respawning. |
 
-  | Sub-elements | | Value/Children |
+  | Sub-elements | | Value |
   |---|---|---|
   | `<item> </item>` | The item that will remain in a player's inventory when they die and respawn. | [Material Name](/docs/reference/items/inventory#material-matchers) |
 </div>

--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -34,16 +34,16 @@ The maps version should follow the versioning schema `major.minor.patch`.
   | Element | Description | Value/Children | Default |
   |---|---|---|---|
   | `<name>` | <span className="badge badge--danger">Required</span>The name of the map. | <span className="badge badge--primary">String</span> |
-  | `<slug>` | The map's slug, usually auto generated from the map's name. This should only be used when a map is renamed to retain the map's ratings, etc.<br />*Valid slugs are lowercase and only contain the characters:* `a-z 0-9 _` | <span className="badge badge--primary">String</span> | <span className="badge badge--secondary">Auto Generated</span> |
-  | `<version>` | <span className="badge badge--danger">Required</span>The map's [semantic version](https://semver.org/) string. | `1.0.0` |
+  | `<slug>` | The map's internal identifier, usually auto generated from the map's name. This should only be used when a map is renamed to retain the map's ratings, etc.<br />*Valid slugs are lowercase and only contain the characters:* `a-z 0-9 _` | <span className="badge badge--primary">String</span> | <span className="badge badge--secondary">Auto Generated</span> |
+  | `<version>` | <span className="badge badge--danger">Required</span>The map's [semantic version](https://semver.org/). | `1.0.0` |
   | `<objective>` | <span className="badge badge--danger">Required</span>The map's objective, shown at the start of the match. | <span className="badge badge--primary">String</span> |
-  | `<authors>` | <span className="badge badge--danger">Required</span>The authors of the map, at least one author is required. | `<author>` |
+  | `<authors>` | <span className="badge badge--danger">Required</span>The authors of the map. At least one author is required. | `<author>` |
   | `<contributors>` | Contributors to the map. | `<contributor>` |
   | `<created>` | The date on which this map was initially released. | `YYYY-MM-DD` |
-  | `<phase>` | The phase of this map.<br />**Note:** By default, it will not appear in the list when a user runs /maps. In legacy PGM, only maps with production and standard show up on a website configured with an API. | `development`<br />`production` | `production` |
-  | `<edition>` | The edition of this map, describing which servers it should run on. | `standard`<br />`ranked`<br />`tournament` | `standard` |
-  | `<game>` | A custom title for this match's gamemode. | <span className="badge badge--primary">String</span> |
-  | `<gamemode>` | The gamemode(s) of this map, if this is not specified the map will set the gamemode(s) to whatever modules are used. | <span className="badge badge--primary">Gamemode ID</span> |
+  | `<phase>` | The stage of development the map is in.<br />**Note:** By default, it will not appear in the list when a user runs `/maps`. In legacy PGM, only maps in production phase show up on a website configured with an API. | `development`<br />`staging`<br />`production` | `production` |
+  | `<edition>` | The type of gameplay environment this map is intended for.<br />**Note:** In legacy PGM, only standard edition maps show up on a website configured with an API. | `standard`<br />`ranked`<br />`tournament` | `standard` |
+  | `<game>` | A custom title for this match's gamemode.<br />**Note:** A map can have multiple gamemode titles. PGM will select the last as the map's primary title. | <span className="badge badge--primary">String</span> |
+  | `<gamemode>` | The gamemode(s) of this map. If this is not specified the map will set the gamemode(s) to whatever modules are used. | <span className="badge badge--primary">Gamemode ID</span> |
 </div>
 
 ```xml
@@ -66,7 +66,7 @@ There can be multiple authors and contributors to a map.
 The contribution attribute should be used to specify what their contribution to the map was.
 
 A player's name should **not** be used to credit them, instead their UUID should be used. 
-A UUID is a unique user identifier that is used to keep track of players even if they change their name. 
+A UUID is a universally unique identifier that is used to keep track of players even if they change their name. 
 You can check player UUIDs at [mcuuid.net](https://mcuuid.net/). 
 If an author or contributor is defined without a UUID, that player will not get any mapmaker perks on the map.
 
@@ -85,7 +85,7 @@ If an author or contributor is defined without a UUID, that player will not get 
   | Attribute | Description | Value |
   |---|---|---|
   | `uuid` | The UUID used to identify a Minecraft player. | <span className="badge badge--primary">String</span> |
-  | `contribution` | The contribution this author or contributor made to the map. | <span className="badge badge--primary">String</span> |
+  | `contribution` | A description of the contribution this author or contributor made to the map. | <span className="badge badge--primary">String</span> |
 </div>
 
 ```xml
@@ -148,13 +148,13 @@ Additionally, a variant can also contain constants, which allows you to define t
   | `<variant> </variant>` | A map variant. | <span className="badge badge--primary">String</span> |
 </div>
 
-#### Variant Attributes
+##### Variant Attributes
 
 <div className="table-container">
   | Attribute | Description | Value | Default |
   |---|---|---|---|
   | `id` | <span className="badge badge--danger">Required</span>Unique identifier used to reference this map variant from other places in the XML. | <span className="badge badge--primary">String</span> |
-  | `world` | Specify the world the variant should use during a match. | <span className="badge badge--primary">String</span> |
+  | `world` | The world the variant should use during a match. | <span className="badge badge--primary">String</span> |
   | `override` | Toggle if the variant name should override the base map name. If set to false, PGM will append `: [variant]` to the base map name. | <span className="badge badge--primary">true/false</span> | false |
 </div>
 
@@ -167,7 +167,7 @@ Additionally, a variant can also contain constants, which allows you to define t
   | `<unless> </unless>` | Apply an XML section for all variants except for a specific variant when loaded. | <span className="badge badge--secondary">XML Modules</span> |
 </div>
 
-#### If/Unless Conditional Attributes
+##### If/Unless Conditional Attributes
 
 <div className="table-container">
   | Attribute | Description | Value |
@@ -192,7 +192,7 @@ PGM will search and replace any corresponding placeholders (`${constant_id}`) wi
   | `<constant> </constant>` | An individual constant. | <span className="badge badge--primary">String</span> |
 </div>
 
-#### Constant Attributes
+##### Constant Attributes
 
 <div className="table-container">
   | Attribute | Description | Value | Default |
@@ -250,33 +250,34 @@ This means that a map that uses destroyables and flags would be displayed as "DT
 <div className="table-container">
   | ID | Description |
   |---|---|
-  | `ad` | Attack/Defend |
   | `arcade` | Arcade |
+  | `ad` | Attack/Defend |
   | `bedwars` | Bed Wars |
   | `blitz` | Blitz |
   | `br` | Blitz: Rage |
   | `bridge` | Bridge |
-  | `cp` | Control the Point |
   | `ctf` | Capture the Flag |
   | `ctw` | Capture the Wool |
+  | `cp` | Control the Point |
+  | `tdm` | Deathmatch |
   | `dtc` | Destroy the Core |
   | `dtm` | Destroy the Monument |
-  | `ffa` | Free for All |
+  | `5cp` | 5 Control Points |
   | `ffb` | Flag Football |
+  | `ffa` | Free for All |
   | `infection` | Infection |
   | `kotf` | King of the Flag |
   | `koth` | King of the Hill |
   | `mixed` | Mixed |
   | `payload` | Payload |
-  | `rage` | Rage |
   | `rfw` | Race for Wool |
+  | `rage` | Rage |
   | `scorebox` | Scorebox |
   | `skywars` | Skywars |
   | `sg` | Survival Games |
-  | `tdm` | Deathmatch |
 </div>
 
-Example
+##### Example
 
 ```xml
 <!-- A FFA map with scoreboxes -->

--- a/docs/modules/information/broadcasts.mdx
+++ b/docs/modules/information/broadcasts.mdx
@@ -42,7 +42,7 @@ It should not be used for generic server-related messages.
 <div className="table-container">
   | Element | Description | Value |
   |---|---|---|
-  | `<filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Duration to wait after the match starts to show the message. | [Filters](/docs/modules/mechanics/filters) |
+  | `<filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter if the broadcast message should be sent after the duration has passed, or if it is skipped. | [Filters](/docs/modules/mechanics/filters) |
 </div>
 
 ### Examples

--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -1,6 +1,7 @@
 ---
 id: actions-triggers
 title: Actions & Triggers
+toc_max_heading_level: 4
 ---
 
 Actions are a set of features that are applied to players, teams, or matches, similiar to [Kits](/docs/modules/gear/kits).
@@ -23,7 +24,11 @@ In the future, some features that are currently used in Kits may be transferred 
   | `<kill-entities/>` | Removes entities based on a filter. |
   | `<kit/>` | Applies a [Kit](/docs/modules/gear/kits). |
   | `<fill/>` | Places blocks in a block-bounded region. |
+  | `<paste-structure/>` | Places a structure at a specified location when triggered. |
   | `<replace-item> </replace-item>` | Finds and replaces certain items. |
+  | `<take-payment> </take-payment>` | Allow players to pay with items in their inventory to trigger an action. |
+  | `<velocity/>` | A player-scoped kit that applies velocity to the player. |
+  | `<teleport/>` | Teleport a player to a specific location. |
 </div>
 
 ### Action Attributes
@@ -61,6 +66,28 @@ In the future, some features that are currently used in Kits may be transferred 
   | `fade-out` | How long the title and subtitle text will fade out. | [Time Period](/docs/reference/misc/time-periods) | 1s |
 </div>
 
+#### Replacements
+
+<div className="table-container">
+  | Element | Description | Value |
+  |---|---|---|
+  | `<replacements>` | A list of replacements.<br />**Note:** In the future, more replacements such as player names will be supported. | <span className="badge badge--secondary">Replacements Sub-elements</span> |
+
+  | Sub-element | Description |
+  |---|---|
+  | `<decimal/>` | A numerical placeholder. |
+</div>
+
+##### Decimal Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
+  | `id` | Unique identifier used to reference this decimal from other places in the XML. | <span className="badge badge--primary">String</span> |
+  | `value` | <span className="badge badge--danger">Required</span>The variable this decimal should evaluate. It can be used with formulas. | <span className="badge badge--primary">Expression</span> |
+  | `format` | Customize how the decimal should be displayed, e.g. `#.00`. | [Java DecimalFormat pattern](https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html) |
+</div>
+
 ### Sound Attributes
 
 <div className="table-container">
@@ -78,7 +105,8 @@ In the future, some features that are currently used in Kits may be transferred 
   | Attribute | Description | Value |
   |---|---|---|
   | `var` | <span className="badge badge--danger">Required</span>The variable to update. | [Variable](/docs/modules/mechanics/variables) |
-  | `value` | <span className="badge badge--danger">Required</span>Sets a new value for the variable. | <span className="badge badge--primary">String</span> |
+  | `index` | If setting an array-type variable, the expression to be evaluated.<br />*Required when using array-type variables.* | <span className="badge badge--primary">Expression</span> |
+  | `value` | <span className="badge badge--danger">Required</span>Sets a new value for the variable. | <span className="badge badge--primary">Expression</span> |
 </div>
 
 ### Kill-Entities Attributes
@@ -96,21 +124,75 @@ In the future, some features that are currently used in Kits may be transferred 
   |---|---|---|---|
   | `region` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>The region to fill in. Multiple regions will be treated as an union. | [Region](/docs/modules/mechanics/regions) |
   | `material` | <span className="badge badge--danger">Required</span>The filling material. | [Single Material Pattern](/docs/reference/items/inventory#material-matchers) |
-  | `filter` | Filters which blocks get affected. *May impact preformace for large fills.* | [Filter](/docs/modules/mechanics/filters) |
-  | `events` | Calls events for block placements and removals, which will make it affected by other filters and PGM features. *May impact preformace for large fills.* | <span className="badge badge--primary">true/false</span> | false |
+  | `filter` | Filters which blocks get affected. *May impact performance for large fills.* | [Filter](/docs/modules/mechanics/filters) |
+  | `events` | Calls events for block placements and removals, which will make it affected by other filters and PGM features. *May impact performance for large fills.* | <span className="badge badge--primary">true/false</span> | false |
 </div>
 
-### Replace Item Attributes/Elements
+### Paste-Structure Attributes
 
 <div className="table-container">
   | Attribute | Description | Value |
   |---|---|---|
-  | `<find />` | The item to find. | [Item Attributes](/docs/modules/gear/items#item-attributes) |
+  | `x` | The X coordinate of the location to paste the structure, measured in east-west. | <span className="badge badge--primary">Expression</span> |
+  | `y` | The Y coordinate of the location to paste the structure, measured in altitude. | <span className="badge badge--primary">Expression</span> |
+  | `z` | The Z coordinate of the location to paste the structure, measured in north-south. | <span className="badge badge--primary">Expression</span> |
+  | `structure` | The structure to paste. | [Structure ID](/docs/modules/blocks/structures) |
+</div>
+
+### Replace Item
+
+#### Sub-elements
+
+<div className="table-container">
+  | Sub-elements | Description | Value |
+  |---|---|---|
+  | `<find/>` | The item to find in a player's inventory. | [Item Attributes](/docs/modules/gear/items#item-attributes) |
   | `<replace/>` | The new item to replace with. | [Item Attributes](/docs/modules/gear/items#item-attributes) |
+</div>
+
+#### Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
   | `keep-amount` | Player recives the same amount of the new item as they had of the old item. | <span className="badge badge--primary">true/false</span> |
   | `keep-enchants` | Enchantments on the old item will be applied to the new item. | <span className="badge badge--primary">true/false</span> |
   | `ignore-metadata` | Filters which entities to remove. | <span className="badge badge--primary">true/false</span> |
   | `amount` | Match for item stacks that have a certain amount of items in a range. | <span className="badge badge--primary">Range</span> |
+</div>
+
+### Take-Payment
+
+#### Sub-elements
+
+<div className="table-container">
+  | Sub-elements | Description | Value |
+  |---|---|---|
+  | `<payment/>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>An individual payment. | [Item Attributes](/docs/modules/gear/items#item-attributes) |
+  | `<success-action/>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The action to trigger upon a successful payment. | <span className="badge badge--primary">Action</span> |
+  | `<fail-action/>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The action to trigger upon a failed payment. | <span className="badge badge--primary">Action</span> |
+</div>
+
+#### Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
+  | `material` | <span className="badge badge--danger">Required</span>The item to display as an icon. | [Material Name](/docs/reference/items/inventory#material-matchers) |
+  | `price` | The amount of a currency needed to purchase. | <span className="badge badge--primary">Number</span> |
+  | `currency` | The currency needed to purchase. | [Filter](/docs/modules/mechanics/filters) |
+</div>
+
+### Velocity & Teleport Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
+  | `x` | The X coordinate, measured in east-west. | <span className="badge badge--primary">Expression</span> |
+  | `y` | The Y coordinate, measured in altitude. | <span className="badge badge--primary">Expression</span> |
+  | `z` | The Z coordinate, measured in north-south. | <span className="badge badge--primary">Expression</span> |
+  | `yaw` | The horizontal angle a user looks to. | <span className="badge badge--primary">Expression</span> |
+  | `pitch` | The vertical angle a user looks to. | <span className="badge badge--primary">Expression</span> |
 </div>
 
 ## Trigger Element
@@ -168,7 +250,7 @@ This example uses the `expose` attribute in Action to allow moderators to enable
 a "Blitz Mode" using the `/action` command. Moderators must have the `GAMEPLAY` permissions
 in order to use `/action`. See [Commands](/docs/commands/main) for more details.
 
-```
+```xml
 <actions>
     <!-- Moderator uses "/action trigger start-blitz" to start this Action -->
     <action id="start-blitz" expose="true" scope="match">

--- a/docs/modules/mechanics/damage.mdx
+++ b/docs/modules/mechanics/damage.mdx
@@ -27,8 +27,8 @@ The difficulty level can be set to `peaceful`, `easy`, `normal`, or `hard`. The 
 
 ### Hunger
 
-Specify if a player can starve to death, usually used with the difficulty setting.<br/>
-This can also be accomplished with the `naturalRegeneration` [gamerule](/docs/modules/mechanics/gamerules).
+Specify if a player can starve to death, usually used with the difficulty setting.
+This can also be accomplished with the [`naturalRegeneration` gamerule](/docs/modules/mechanics/gamerules).
 
 ```xml
 <hunger>
@@ -94,6 +94,14 @@ While almost every form of damage can be disabled safely, it is recommended that
   | `<damage> </damage>` | The damage type that is disabled. | [Damage Cause](#damage-causes) |
 </div>
 
+#### Damage Attributes
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
+  | `attacker-action` | The action to trigger for the attacker. | [Action ID](/docs/modules/mechanics/actions-triggers) |
+  | `victim-action` | The action to trigger for the victim. | [Action ID](/docs/modules/mechanics/actions-triggers) |
+</div>
+
 _Example_
 
 ```xml
@@ -101,6 +109,15 @@ _Example_
     <!-- Disable fall damage -->
     <damage>fall</damage>
 </disabledamage>
+```
+
+```xml
+<!-- Deny explosions & use actions "when-attacking" and "when-damaged" -->
+<damage attacker-action="when-attacking" victim-action="when-damaged">
+    <deny>
+        <cause>explosion</cause>
+    </deny>
+</damage>
 ```
 
 #### Block Explosion Attributes

--- a/docs/modules/mechanics/spawns.mdx
+++ b/docs/modules/mechanics/spawns.mdx
@@ -140,7 +140,7 @@ If a player has a bed spawn location set, it overrides all other spawn regions f
   | `auto` | Automatically respawn the player after the delay time has elapsed. | <span className="badge badge--primary">true/false</span> | false |
   | `blackout` | Dead players get a blindness effect applied. | <span className="badge badge--primary">true/false</span> | false |
   | `spectate` | Allow dead players to fly around. | <span className="badge badge--primary">true/false</span> | false |
-  | `bed` | <span className="badge badge--danger">N/A</span>Allow players to respawn from beds. | <span className="badge badge--primary">true/false</span> | false |
+  | `bed` | <span className="badge badge--danger" title="This feature once existed, but has not been re-implemented in modern versions of PGM.">N/A</span>Allow players to respawn from beds. | <span className="badge badge--primary">true/false</span> | false |
   | `message` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Message to display on the respawn screen to respawning players. | <span className="badge badge--primary">Formatted Text</span> |
 </div>
 

--- a/docs/modules/mechanics/tracking-compass.mdx
+++ b/docs/modules/mechanics/tracking-compass.mdx
@@ -1,0 +1,65 @@
+---
+id: tracking-compass
+title: Tracking Compass
+---
+
+The Tracking Compass module allows you to override the vanilla compass behavior by pointing
+it to a player of interest. In addition, you can control how the compass selects the target to track.
+
+#### Compass Element
+
+<div className="table-container">
+  | Element | Description |
+  |---|---|
+  | `<compass> </compass>` | Node containing all compass properties used in this map. |
+
+  | Sub-element ||
+  |---|---|
+  | `<player>` | An individual compass property pointing to the nearest player passing a filter. |
+  | `<flag>` | An individual compass property pointing to a specific flag. |
+</div>
+
+##### Compass Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value | Default |
+  |---|---|---|---|
+  | `order` | When using `DEFINITION_ORDER`, the compass targets first matching target. When using `CLOSEST`, the compass goes through all matching targets and chooses the one closest to the player. | `DEFINITION_ORDER`<br />`CLOSEST` |
+  | `show-distance` | Show the distance between the compass holder and tracked player in meters. | <span className="badge badge--primary">true/false</span> | false |
+</div>
+
+##### Player/Flag Attribute
+
+<div className="table-container">
+  | Attribute | Description | Value | Default |
+  |---|---|---|---|
+  | `filter` | Filters who should be tracked by the compass. | [Filter](/docs/modules/mechanics/filters) |
+  | `holder-filter` | Filters out what compass targets can be eligible for what players, e.g. a team targets a different flag than the other team. | [Filter](/docs/modules/mechanics/filters) |
+  | `name` | The title name that describes the tracked flag or player's role, e.g. "Wool Carrier." | <span className="badge badge--primary">Formatted Text</span> |
+  | `show-player` | Show the tracked player's username to the compass holder.<br />**Note:** This is only applicable to `<player>` sub-element. | <span className="badge badge--primary">true/false</span> | false |
+</div>
+
+## Examples
+
+```xml
+<compass show-distance="true">
+    <player filter="always" show-player="true"/>
+</compass>
+
+<compass>
+    <player filter="always" name="Wool Carrier"/>
+</compass>
+
+<compass order="DEFINITION_ORDER">
+    <player filter="wool-carrier" name="Wool Carrier"/>
+    <player filter="enemy" show-player="true" name="Nearest Enemy"/>
+</compass>
+
+<compass>
+    <player holder-filter="red-team" filter="blue-carrier" show-player="true"/>
+    <flag holder-filter="red-team">blue-flag</flag>
+    
+    <player holder-filter="blue-team" filter="red-carrier" show-player="true"/>
+    <flag holder-filter="blue-team" name="Some other name">red-flag</flag>
+</compass>
+```

--- a/docs/modules/mechanics/variables.mdx
+++ b/docs/modules/mechanics/variables.mdx
@@ -21,7 +21,9 @@ You can define as many variables as you want and all variables must have a scope
   | `<score/>` | A score variable, allowing direct access to competitor's score. This is automatically scoped to teams. |
   | `<timelimit/>` | A time limit variable which starts/stops the time limit of the match. |
   | `<maxbuildheight/>` | A variable that sets the build height of the map. |
+  | `<array/>` | A variable that represents a collection of values. |
   | `<with-team/>` | A team-rescoping variable that allows using a specific team's value from a different team-scoped variable as a match-scoped variable. |
+  | `<player-location/>` | A variable that reads a player's location components. |
 </div>
 
 ### Variable Attributes
@@ -35,6 +37,15 @@ You can define as many variables as you want and all variables must have a scope
   | `default` | Sets the initial value of the variable. | <span className="badge badge--primary">Number</span> |
 </div>
 
+### Array Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
+  | `id` | Unique identifier used to reference this array-type variable from other places in the XML. | <span className="badge badge--primary">String</span> |
+  | `size` | <span className="badge badge--danger">Required</span>The size of this array. | <span className="badge badge--primary">1 - 1024</span> |
+</div>
+
 ### With-Team Attributes
 
 <div className="table-container">
@@ -43,6 +54,15 @@ You can define as many variables as you want and all variables must have a scope
   | `id` | Unique identifier used to reference this with-team variable from other places in the XML. | <span className="badge badge--primary">String</span> |
   | `var` | The variable to target. | [Variable ID](#variable-attributes) |
   | `team` | The team to target. | [Team ID](/docs/modules/format/teams#team-attributes) |
+</div>
+
+### Player-Location Attributes
+
+<div className="table-container">
+  | Attribute | Description | Value |
+  |---|---|---|
+  | `id` | Unique identifier used to reference this player-location variable from other places in the XML. | <span className="badge badge--primary">String</span> |
+  | `component` | The player's location component to target. `XYZ`, `YAW`, and `PITCH` represents the player's position/angle, `DIR_XYZ` represents the player's direction, and `VEL_XYZ` represents the player's velocity.  | `X`, `Y`, `Z`, `PITCH`, `YAW`,<br />`DIR_X`, `DIR_Y`, `DIR_Z`,<br />`VEL_X`, `VEL_Y`, and `VEL_Z` |
 </div>
 
 ## Examples

--- a/docs/modules/objectives/scoring.mdx
+++ b/docs/modules/objectives/scoring.mdx
@@ -61,7 +61,7 @@ A score box will give points to a players team when they enter or bring a redeem
   | `silent` | Do not notify players when points are scored in this box. | <span className="badge badge--primary">true/false</span> | false |
   | `region` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>The location and size of the score box. | [Region](/docs/modules/mechanics/regions) |
   | `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter who can score in this box. | [Filter](/docs/modules/mechanics/filters) | <span className="badge badge--secondary">No Filter</span> |
-  | `trigger` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Dynamic conditions under which this score box is applied. | [Dynamic Filter](/docs/modules/mechanics/filters#dynamic-filters) |
+  | `trigger` | <span className="badge badge--danger" title="This feature once existed, but has not been re-implemented in modern versions of PGM.">N/A</span><span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Dynamic conditions under which this score box is applied. | [Dynamic Filter](/docs/modules/mechanics/filters#dynamic-filters) |
 </div>
 
 #### Box Sub-elements

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,7 +86,7 @@ const config = {
      announcementBar: {
       id: 'new_features',
       content:
-        'New Features: <a href="/docs/modules/gear/consumables">Consumables</a>, <a href="/docs/modules/general/main#map-variants">Map Variants</a>, <a href="/docs/modules/general/main#constants">Constants</a>, and <a href="/docs/modules/blocks/structures">Structures</a>',
+        'New Features: <a href="/docs/modules/mechanics/tracking-compass">Tracking Compass</a>, <a href="/docs/modules/gear/consumables">Consumables</a>, <a href="/docs/modules/general/main#map-variants">Map Variants</a>, and <a href="/docs/modules/general/main#constants">Constants</a>',
       backgroundColor: '#fafbfc',
       textColor: '#091E42',
       isCloseable: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@docusaurus/core": "^3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
-        "@fortawesome/fontawesome-svg-core": "^6.5.2",
-        "@fortawesome/free-solid-svg-icons": "^6.5.2",
+        "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@mdx-js/react": "^3.0.1",
         "classnames": "^2.5.1",
@@ -2797,33 +2797,33 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
-      "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
-      "hasInstallScript": true,
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
+      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
-      "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
-      "hasInstallScript": true,
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
+      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
+      "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.5.2"
+        "@fortawesome/fontawesome-common-types": "6.6.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
-      "integrity": "sha512-QWFZYXFE7O1Gr1dTIp+D6UcFUF0qElOnZptpi7PBUMylJh+vFmIedVe1Ir6RM1t2tEQLLSV1k7bR4o92M+uqlw==",
-      "hasInstallScript": true,
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.5.2"
+        "@fortawesome/fontawesome-common-types": "6.6.0"
       },
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@docusaurus/core": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
-    "@fortawesome/fontawesome-svg-core": "^6.5.2",
-    "@fortawesome/free-solid-svg-icons": "^6.5.2",
+    "@fortawesome/fontawesome-svg-core": "^6.6.0",
+    "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@mdx-js/react": "^3.0.1",
     "classnames": "^2.5.1",

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,7 +53,8 @@ const sidebars = {
       "modules/mechanics/lanes",
       "modules/mechanics/damage",
       "modules/mechanics/gamerules",
-      "modules/mechanics/spawners",],
+      "modules/mechanics/spawners",
+      "modules/mechanics/tracking-compass"],
     },
     {
       type: 'category',


### PR DESCRIPTION
Part two of the big branch.

**Commands**
* Disabled unused table of content sidebar for all three command pages to give the table more room, especially on larger screens
* Added filter to PGM command, resolves #97
* Split /pgm into more commands

**Main Map Element**
* Clarified some more on certain things, with help from @Mew2K
* Document `staging` as a phase addition, sourced from PGMDev/PGM#1327

**Broadcast**
* Retyped a duplicated table row (how could you tell I copied and pasted these a while ago?)

**Actions**
* Documented new `<take-payment>`, sourced from PGMDev/PGM#1305

**Tracking Compass**
I've made a new page covering this. I've sourced information from PGMDev/PGM#1308 and PGMDev/PGM#1333.

As usual, I appreciate any feedback and correction