### PR TITLE
Remove sub-elements property tables

### DIFF
--- a/docs/modules/blocks/blockdrops.mdx
+++ b/docs/modules/blocks/blockdrops.mdx
@@ -33,23 +33,15 @@ Blocks broken by means other than mining or explosions currently do not cause cu
 | `wrong-tool` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Drop items regardless of what tool was used to mine the block. | <span className="badge badge--primary">true/false</span> | false |
 | `punch` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Check this rule when a block is punched. | <span className="badge badge--primary">true/false</span> | false |
 | `trample` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Check this rule when a block is walked on. | <span className="badge badge--primary">true/false</span> | false |
+| `fall-chance` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The percentage of blocks that will change to falling blocks when exploded. | <span className="badge badge--primary">0 - 1.0</span> |
+| `land-chance` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The percentage of falling blocks that will change back to real blocks when they land. | <span className="badge badge--primary">0 - 1.0</span> |
+| `fall-speed` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>A multiplier for the velocity of the blocks flying out from a explosion. | <span className="badge badge--primary">Number</span> |
 
 #### Rule Sub-elements
 
-| Element | Description | Value/Children | Default |
-|---|---|---|---|
-| `<filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter what blocks get modified by this rule. | [Filters](/docs/modules/mechanics/filters) |
-| `<region>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The region this rule applies to. | [Regions](/docs/modules/mechanics/regions) |
-| `<kit>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The kit to give players when this rule applies. | [Kits](/docs/modules/gear/kits) |
-| `<drops>` | The items which get dropped when a matching block is mined. | [Items](/docs/modules/gear/items)| |
-| `<experience>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The amount of XP that gets dropped. | <span className="badge badge--primary">Number</span> |
-| `<replacement>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>What to replace the mined block with. | [Single Material Pattern](/docs/reference/items/inventory#material-matchers) | <span className="badge badge--secondary">Air</span> |
-| `<wrong-tool>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Drop items regardless of what tool was used to mine the block. | <span className="badge badge--primary">true/false</span> | false |
-| `<punch>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Check this rule when a player in adventure mode punches a block. | <span className="badge badge--primary">true/false</span> | false |
-| `<trample>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Check this rule when a block is walked on. | <span className="badge badge--primary">true/false</span> | false |
-| `<fall-chance>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The percentage of blocks that will change to falling blocks when exploded. | <span className="badge badge--primary">0 - 1.0</span> |
-| `<land-chance>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The percentage of falling blocks that will change back to real blocks when they land. | <span className="badge badge--primary">0 - 1.0</span> |
-| `<fall-speed>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>A multiplier for the velocity of the blocks flying out from a explosion. | <span className="badge badge--primary">Number</span> |
+| Element | Description | Value/Children |
+|---|---|---|
+| `<drops>` | The items which get dropped when a matching block is mined. | [Items](/docs/modules/gear/items)|
 
 #### Block Drops Item Attributes
 
@@ -69,7 +61,7 @@ This value can range from 0 to 1, a chance of 0.5 would mean that the item will 
 By default, custom drops will not appear if a block is mined with the "wrong" tool, e.g., stone mined with a shovel.
 If `wrong-tool` is set to true, the custom drops will happen regardless of what tool was used.
 
-### Examples
+## Examples
 
 ```xml
 <block-drops>
@@ -180,14 +172,6 @@ Additionally the `<sprinting/>`, `<walking/>`, and `<crouching/>` filters used i
 ### Explosion behavior
 
 The behavior for blocks that become airborne due to explosions can be modified in addition to all the other drop rules.
-
-#### Rule Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<fall-chance>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The percentage of blocks that will change to falling blocks when exploded. | <span className="badge badge--primary">0 - 1.0</span> |
-| `<land-chance>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The percentage of falling blocks that will change back to real blocks when they land. | <span className="badge badge--primary">0 - 1.0</span> |
-| `<fall-speed>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>A multiplier for the velocity of the blocks flying out from a explosion. | <span className="badge badge--primary">Number</span> |
 
 ```xml
 <block-drops>

--- a/docs/modules/blocks/falling-blocks.mdx
+++ b/docs/modules/blocks/falling-blocks.mdx
@@ -25,17 +25,9 @@ Entire structures can then be built from those blocks, and they will not collaps
 
 | Attribute | Description | Value | Default |
 |---|---|---|---|
-| `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>Filter what blocks get modified by this rule. | [Block Filter](/docs/modules/mechanics/filters) |
+| `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>Filter what blocks get modified by this rule.<br />*Also accepts regions to limit the rule to a certain area.* | [Block Filter](/docs/modules/mechanics/filters) &amp;<br />[Regions](/docs/modules/mechanics/regions) |
 | `sticky` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>The blocks that are sticky. | [Block Filter](/docs/modules/mechanics/filters) |
 | `delay` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Tick delay until blocks start to fall after they have been disturbed. | <span className="badge badge--primary">Number</span> | 2 |
-
-#### Rule Sub-elements
-
-| Element | Description | Value/Children | Default |
-|---|---|---|---|
-| `<filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>Filter what blocks get modified by this rule.<br />*Also accepts regions to limit the rule to a certain area.* | [Block Filters](/docs/modules/mechanics/filters) &amp;<br />[Regions](/docs/modules/mechanics/regions) |
-| `<sticky>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>The blocks that are sticky. | [Block Filter](/docs/modules/mechanics/filters) |
-| `<delay>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Tick delay till blocks start to fall after they have been disturbed. | <span className="badge badge--primary">Number</span> | 2 |
 
 ### Examples
 

--- a/docs/modules/blocks/renewables.mdx
+++ b/docs/modules/blocks/renewables.mdx
@@ -34,15 +34,6 @@ If neither are specified, the renewable affects all blocks in the world.
 | `sound` | Play block restore sound effects. | <span className="badge badge--primary">true/false</span> | true |
 | `avoid-players` | Prevent blocks from being restored within a specific number of distance from any player. | <span className="badge badge--primary">block</span> | 2 |
 
-#### Renewable Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The region the renewable applies to. | [Bounded Regions](/docs/modules/mechanics/regions) |
-| `<renew-filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter which blocks are renewed. | [Filters](/docs/modules/mechanics/filters) |
-| `<replace-filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter which blocks are replaced. | [Filters](/docs/modules/mechanics/filters) |
-| `<shuffle-filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter which blocks are shuffled. | [Filters](/docs/modules/mechanics/filters) |
-
 ### Examples
 
 By default, all blocks in the region are renewable. 

--- a/docs/modules/environment/border.mdx
+++ b/docs/modules/environment/border.mdx
@@ -30,12 +30,6 @@ Attributes for multiple world borders can be applied for all borders by specifyi
 | `warning-distance` | Specify the block distance to the border before showing a red vignette to players. | <span className="badge badge--primary">Number</span> | 5 |
 | `warning-time` | Show red vignette to players when the border is moving and will reach them within the specified time. | [Time Period](/docs/reference/misc/time-periods) | 15s |
 
-##### World Border Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<when>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter when this world border is in effect. | [Filters](/docs/modules/mechanics/filters) |
-
 ### Examples
 
 ```xml

--- a/docs/modules/environment/mobs.mdx
+++ b/docs/modules/environment/mobs.mdx
@@ -15,10 +15,6 @@ Mob spawns can also be filtered against any other filter type, including regions
 |---|---|---|
 | `filter` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>Filter what mobs can spawn when and where. | [Filters](/docs/modules/mechanics/filters) |
 
-| Sub-elements |||
-|---|---|---|
-| `<filter> </filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>Filter what mobs can spawn when and where. | [Filters](/docs/modules/mechanics/filters) |
-
 ##### Mob Spawning Filter Matchers
 
 | Element | Description | Value |

--- a/docs/modules/gear/kill-rewards.mdx
+++ b/docs/modules/gear/kill-rewards.mdx
@@ -35,10 +35,6 @@ Then, once they have collected enough ingots, they can craft armor, purchase ite
 | Element | Description | Value/Children |
 |---|---|---|
 | `<item>` | Individual items given as a kill reward. | [Item](/docs/modules/gear/items) |
-| `<filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter who can claim this reward and when. | [Filter](/docs/modules/mechanics/filters) |
-| `<kit>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The kit to give players as the kill reward. | [Kit](/docs/modules/gear/kits) |
-| `<action>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The action to run as the kill reward. | [Action](/docs/modules/mechanics/actions-triggers) |
-| `<victim-action>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The action to run on the victim. | [Action](/docs/modules/mechanics/actions-triggers) |
 
 ## Examples
 

--- a/docs/modules/gear/pickups.mdx
+++ b/docs/modules/gear/pickups.mdx
@@ -38,15 +38,6 @@ A `<point>` region does not return a randomized position but can still be used t
 | `effects` | Show the pickup's particle effects. | <span className="badge badge--primary">true/false</span> | true |
 | `sounds` | Play the pickup's sound effects. | <span className="badge badge--primary">true/false</span> | true |
 
-##### Pickup Sub-elements
-
-| Element | Description | Value | Default |
-|---|---|---|---|
-| `<spawn-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter if this pickup is and can be spawned. | [Filters](/docs/modules/mechanics/filters) | `always` |
-| `<pickup-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter who can pick up the pickup's kit. | [Filters](/docs/modules/mechanics/filters) | `always` |
-| `<region>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>The region where this pickup is placed into. | [Randomize-able Regions](/docs/modules/mechanics/regions) |
-| `<kit>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The kit to give to players who pick up this pickup. | [Kits](/docs/modules/gear/kits) |
-
 ### Examples
 
 ```xml

--- a/docs/modules/gear/projectiles.mdx
+++ b/docs/modules/gear/projectiles.mdx
@@ -29,17 +29,10 @@ or the item form of the custom projectile itself.
 | `damage` | The amount of damage this projectile deals. | <span className="badge badge--primary">Half-hearts</span> | 0.0 |
 | `velocity` | The speed at which the projectile moves. | <span className="badge badge--primary">Meters/tick</span> | 1.0 |
 | `click` | The click action that fires the projectile. | `right`,<br />`left`,<br />or `both` | `both` |
-| `effects` | The potion effects to apply to players hit by this projectile. | [Potion Effect](/docs/modules/gear/potions) |
+| `effect` | The potion effects to apply to players hit by this projectile. | [Potion Effect](/docs/modules/gear/potions) |
 | `destroy-filter` | <span className="badge badge--secondary" title="Can be this attribute or a sub-element.">Property</span>Filter if/what blocks get destroyed when hit with this projectile. | [Filter](/docs/modules/mechanics/filters) | `never` |
 | `cooldown` | The minimum time between each firing of this projectile. | [Time Period](/docs/reference/misc/time-periods) |
 | `precise` | Whether the path of a thrown projectile should be precise in hitting a target.<br />*This is only applicable if the projectile is `Fireball`, `LargeFireball`, `SmallFireball`, or `WitherSkull`.* | <span className="badge badge--primary">true/false</span> | true |
-
-##### Projectile Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<destroy-filter>` | <span className="badge badge--secondary" title="Can be this sub-element or an attribute.">Property</span>Filter if/what blocks get destroyed when hit with this projectile. | [Filters](/docs/modules/mechanics/filters) |
-| `<effect>` | A potion effect to apply to players hit by this projectile. | [Potion Effects](/docs/modules/gear/potions) |
 
 ```xml
 <!-- Create the projectile "lazer" -->

--- a/docs/modules/information/broadcasts.mdx
+++ b/docs/modules/information/broadcasts.mdx
@@ -33,12 +33,6 @@ It should not be used for generic server-related messages.
 | `count` | Amount of times the message is repeated.<br />*Infinite repetition can be specified by using `oo` as the duration.* | <span className="badge badge--primary">Number</span> |
 | `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter if the broadcast message should be sent after the duration has passed, or if it is skipped. | [Filter](/docs/modules/mechanics/filters) |
 
-##### Message Tag Sub-elements
-
-| Element | Description | Value |
-|---|---|---|
-| `<filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter if the broadcast message should be sent after the duration has passed, or if it is skipped. | [Filters](/docs/modules/mechanics/filters) |
-
 ### Examples
 
 ```xml

--- a/docs/modules/mechanics/portals.mdx
+++ b/docs/modules/mechanics/portals.mdx
@@ -37,18 +37,10 @@ Copy the yaw and pitch from the [Debug screen (`F3`)](https://minecraft.wiki/w/D
 | `smooth` | Smoothly teleport players. | <span className="badge badge--primary">true/false</span> | false |
 | `yaw` | Specify the direction the player is looking horizontally from -180&deg; to 180&deg;.<br />*South 0&deg;, East -90&deg;, North 180&deg;, and West 90&deg;.* | <span className="badge badge--primary">Number</span> |
 | `pitch` | Specify the direction the player is looking vertically from -90&deg; to 90&deg;.<br />*-90&deg; is straight up, 90&deg; is straight down.* | <span className="badge badge--primary">Number</span> |
-
-#### Portal Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Region where this portals entrance is located. | [Regions](/docs/modules/mechanics/regions) |
-| `<destination>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Destination of the portal, teleports players to a random point inside the region.<br />*Region is automatically filtered against block place.* | [Randomize-able Regions](/docs/modules/mechanics/regions) |
-| `<filter>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter portal player access. | [Filters](/docs/modules/mechanics/filters) |
-| `<forward>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Apply forward transform on rising edge. | [Dynamic Filters](/docs/modules/mechanics/filters#dynamic-filters) |
-| `<reverse>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Apply reverse transform on rising edge. | [Dynamic Filters](/docs/modules/mechanics/filters#dynamic-filters) |
-| `<transit>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Apply forward transform on rising edge and reverse transform on falling edge.<br />*Cannot combine transit property with `forward` or `reverse` properties.* | [Dynamic Filters](/docs/modules/mechanics/filters#dynamic-filters) |
-| `<observers>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter portal observer access. | [Filters](/docs/modules/mechanics/filters) |
+| `forward` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Apply forward transform on rising edge. | [Dynamic Filter](/docs/modules/mechanics/filters#dynamic-filters) |
+| `reverse` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Apply reverse transform on rising edge. | [Dynamic Filter](/docs/modules/mechanics/filters#dynamic-filters) |
+| `transit` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Apply forward transform on rising edge and reverse transform on falling edge.<br />*Cannot combine transit property with `forward` or `reverse` properties.* | [Dynamic Filter](/docs/modules/mechanics/filters#dynamic-filters) |
+| `observers` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter portal observer access. | [Filter](/docs/modules/mechanics/filters) |
 
 ### Examples
 

--- a/docs/modules/mechanics/proximity-alarms.mdx
+++ b/docs/modules/mechanics/proximity-alarms.mdx
@@ -33,7 +33,6 @@ This is how the alarm can be made "silent", so that enemies may not realize that
 
 | Element | Description | Value/Children |
 |---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span><span className="badge badge--danger">Required</span>The region this alarm applies to, treated as a region union. | [Regions](/docs/modules/mechanics/regions) |
 | `<detect>` | Filter who gets detected by the proximity alarm. | [Filter](/docs/modules/mechanics/filters) |
 | `<notify>` | Filter who gets notified by the proximity alarm. | [Filter](/docs/modules/mechanics/filters) |
 

--- a/docs/modules/mechanics/regions.mdx
+++ b/docs/modules/mechanics/regions.mdx
@@ -276,15 +276,9 @@ Copy the yaw and pitch from the [Debug screen (`F3`)](https://minecraft.wiki/w/D
 
 | Attribute | Description | Value |
 |---|---|---|
-| `region` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The region the point provider modifies. | [Randomize-able Region](#block-bounded-regions) |
+| `region` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The region (or regions) the point provider modifies. | [Randomize-able Region](#block-bounded-regions) |
 | `yaw` | Specifies what direction the player is looking horizontally from -180&deg; to 180&deg;.<br />*South 0&deg;, East -90&deg;, North 180&deg;, and West 90&deg;.* | <span className="badge badge--primary">-180 to 180</span> |
 | `pitch` | Specifies what direction the player is looking vertically from -90&deg; to 90&deg;.<br />*-90&deg; is straight up, 90&deg; is straight down.* | <span className="badge badge--primary">-90 to 90</span> |
 | `angle` | Specify the exact block coordinates that the player should look at.<br />*This attribute will negate any angles set by the `yaw` and `pitch` attributes.* | <span className="badge badge--primary">X,Y,Z</span> |
-
-##### Point Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The region or regions the point provider modifies. | [Randomize-able Region](#block-bounded-regions) |
 
 **Note:** The pitch and yaw arguments can also accept a `X,Y,Z` coordinate.

--- a/docs/modules/mechanics/spawns.mdx
+++ b/docs/modules/mechanics/spawns.mdx
@@ -31,6 +31,7 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
 | Attribute | Description | Value | Default |
 |---|---|---|---|
 | `team` | The team this spawn applies to.<br />*Not needed for team-less gamemodes.* | [Team ID](/docs/modules/format/teams) |
+| `region` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The region or regions where players will spawn. | [Regions](/docs/modules/mechanics/regions) |
 | `safe` | Validate that the player spawns in a safe location. | <span className="badge badge--primary">true/false</span> | false |
 | `sequential` | Spawns players at the next region in a list if the one prior to it is not safe.<br />*Requires the `safe` attribute set to true.* | <span className="badge badge--primary">true/false</span> | false |
 | `spread` | Spawn players as far away as possible from enemy players. | <span className="badge badge--primary">true/false</span> | false |
@@ -39,12 +40,6 @@ Respawn behavior such as delays, etc. can be customized with the [respawn](#resp
 | `persistent` | Once a player has been assigned a spawn, they will spawn there even if they leave and rejoin the game. | <span className="badge badge--primary">true/false</span> | false |
 | `kit` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>The kit to apply to players when they are spawned in this spawn. | [Kit ID](/docs/modules/gear/kits) |
 | `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter when this spawn is used. | [Filter](/docs/modules/mechanics/filters) |
-
-#### Spawn & Default Element Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<regions>` | The region or regions where players will spawn. | [Regions](/docs/modules/mechanics/regions) |
 
 #### Regions Element Attributes
 
@@ -132,11 +127,7 @@ If a player has a bed spawn location set, it overrides all other spawn regions f
 | `bed` | <span className="badge badge--danger" title="This feature once existed, but has not been re-implemented in modern versions of PGM.">N/A</span>Allow players to respawn from beds. | <span className="badge badge--primary">true/false</span> | false |
 | `message` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Message to display on the respawn screen to respawning players. | <span className="badge badge--primary">Formatted Text</span> |
 
-##### Respawn Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<message>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Message to display on the respawn screen to respawning players. | <span className="badge badge--primary">Formatted Text</span> |
+### Examples
 
 ```xml
 <!-- Default auto respawn of 2 seconds -->

--- a/docs/modules/objectives/control-points.mdx
+++ b/docs/modules/objectives/control-points.mdx
@@ -69,16 +69,6 @@ Other uses of control points include unlocking an area of the map using objectiv
 | `capture-filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter teams that can capture this control point, defaults to all teams. Teams that don't match this filter can still prevent other teams from capturing by standing on the control point. They can also uncapture the control point if neutral-state is enabled. | [Filter](/docs/modules/mechanics/filters) |
 | `player-filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter players who can control this control point. Players who don't match this filter cannot affect the control point in any way. | [Filter](/docs/modules/mechanics/filters) |
 
-#### Control Point Sub-elements
-
-| Element | Description | Value |
-|---|---|---|
-| `<capture>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>The region where players must stand to capture this control point. | [Regions](/docs/modules/mechanics/regions) |
-| `<progress>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The region where colored blocks within this area point will progressively fade into the controlling team's color. | [Bounded Regions](/docs/modules/mechanics/regions) |
-| `<captured>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>The region where colored blocks within this area will display only the controlling team's color without fading. | [Bounded Regions](/docs/modules/mechanics/regions) |
-| `<capture-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter teams that can capture this control point, defaults to all teams. Teams that don't match this filter can still prevent other teams from capturing by standing on the control point. They can also uncapture the control point if neutral-state is enabled. | [Filters](/docs/modules/mechanics/filters) |
-| `<player-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter players who can control this control point. Players who don't match this filter cannot affect the control point in any way. | [Filters](/docs/modules/mechanics/filters) |
-
 ## Capture Rule
 
 The capture rule defines the logic used to decide which team is in control of the point.
@@ -108,7 +98,7 @@ Use the `<control-point>` and `<control-points>` tags, which work the same but
 with differrent default values.
 :::
 
-KotH is a gamemode in which you capture and hold a hill to collect points.
+King of the Hill is a gamemode in which you capture and hold a hill to collect points.
 The first team to reach a preset amount of points wins.
 
 KotH maps use control points to define hills.

--- a/docs/modules/objectives/ctf.mdx
+++ b/docs/modules/objectives/ctf.mdx
@@ -85,13 +85,7 @@ Filters can be used to control who can pickup/capture the flag and when.
 
 | Element | Description | Value |
 |---|---|---|
-| `<net>` | A net where only this flag can be captured, flags accept multiple net sub-elements. |
-| `<post>X,Y,Z</post>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>The flag's initial & default post. | [Point Provider](/docs/modules/mechanics/regions#point-providers) |
-| `<pickup-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter who can pickup the flag. | [Filters](/docs/modules/mechanics/filters) |
-| `<drop-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter if the flag can be dropped at the current location. | [Filters](/docs/modules/mechanics/filters) |
-| `<capture-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter who can capture the flag. | [Filters](/docs/modules/mechanics/filters) |
-| `<pickup-kit>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Given to players when they pick up the flag. | [Kit](/docs/modules/gear/kits) |
-| `<drop-kit>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Given to flag carriers when they lose the flag, for whatever reason. | [Kit](/docs/modules/gear/kits) |
+| `<net>` | A net where only this flag can be captured, flags accept multiple net sub-elements. | <span className="badge badge--secondary">Net Sub-elements</span> |
 
 ### Posts
 
@@ -116,7 +110,7 @@ The `permanent` option can be used to make a post into something like a [monumen
 
 | Element | Description | Value/Children |
 |---|---|---|
-| `<post>X,Y,Z</post>` | A point or region(s) for flags to spawn at. | [Point Provider](/docs/modules/mechanics/regions#point-providers) |
+| `<post>X,Y,Z</post>` | A point or region(s) for flags to spawn at. | [Point Provider](/docs/modules/mechanics/regions#point-providers) | <span className="badge badge--secondary">Net Sub-elements</span> |
 
 #### Post Attributes
 
@@ -159,7 +153,7 @@ If the net has no owner, then the player carrying the flag will receive the poin
 
 | Element | Description | Value/Children |
 |---|---|---|
-| `<net>` | A region that flags can be captured in. | <span className="badge badge--secondary">Net Sub-elements.</span> |
+| `<net>` | A region that flags can be captured in. | <span className="badge badge--secondary">Net Sub-elements</span> |
 
 #### Net Attributes
 
@@ -179,14 +173,6 @@ If the net has no owner, then the player carrying the flag will receive the poin
 | `respawn-filter` | <span className="badge badge--secondary" title="Can be this attribute or a sub-element.">Property</span>Filter when the flags captured in this net are allowed to respawn. | [Filter](/docs/modules/mechanics/filters) |
 | `respawn-message` | Custom message to broadcast in chat when flag respawn is prevented by a special rule or filter.<br />This can be used to explain an unusual `respawn-filter` to confused players. | <span className="badge badge--primary">Formatted Message</span> |
 | `location` | Location where the net can be found at, used to determine proximity. | <span className="badge badge--primary">X,Y,Z</span> | <span className="badge badge--secondary">Net Region Center</span> |
-
-#### Net Sub-elements
-
-| Element | Description | Value/Children |
-|---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>The region flag carriers must enter to capture in this net. | [Regions](/docs/modules/mechanics/regions) |
-| `<capture-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter players who can capture in this net. | [Filters](/docs/modules/mechanics/filters) |
-| `<respawn-filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter when the flags captured in this net are allowed to respawn. | [Filters](/docs/modules/mechanics/filters) |
 
 ## Examples
 

--- a/docs/modules/objectives/ctw.mdx
+++ b/docs/modules/objectives/ctw.mdx
@@ -54,12 +54,6 @@ The victory monument's area, where the wool block is placed, is protected by def
 | `monument-proximity-metric` | Metric used to determine proximity to the monument. | `player`<br />`closest block`<br />`closest kill`<br />`none` | `closest block` |
 | `monument-proximity-horizontal` | Only calculate horizontal distance for monument proximity. | <span className="badge badge--primary">true/false</span> | false |
 
-##### Wool Sub-elements
-
-| Element | Description | Value |
-|---|---|---|
-| `<monument>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>The monument where the wool must be placed. | [Region](/docs/modules/mechanics/regions) |
-
 ### Examples
 
 You can group multiple victory monuments from the same team inside a single `<wools team="team-id">` element; and then define that teams individual wool colors inside of a `<wool>` element.

--- a/docs/modules/objectives/dtc.mdx
+++ b/docs/modules/objectives/dtc.mdx
@@ -43,12 +43,6 @@ This can also be avoided by keeping the lava far away enough from the core and n
 | `proximity-metric` | Metric used to determine proximity to the core.<br />Accepts `closest player`, `closest block`, `closest kill`, or `none`. | <span className="badge badge--primary">Proximity Metric</span> | `closest player` |
 | `proximity-horizontal` | Only calculate horizontal distance for core proximity. | <span className="badge badge--primary">true/false</span> | false |
 
-#### Core Sub-elements
-
-| Element | Description | Value |
-|---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>A region containing the core. | [Bounded Regions](/docs/modules/mechanics/regions) |
-
 ### Examples
 
 ```xml

--- a/docs/modules/objectives/dtm.mdx
+++ b/docs/modules/objectives/dtm.mdx
@@ -44,12 +44,6 @@ For example, if the monument is obsidian and completion is set to 100%, then all
 | `proximity-metric` | Metric used to determine proximity to the destroyable.<br />Accepts `closest player`, `closest block`, `closest kill`, or `none`. | <span className="badge badge--primary">Proximity Metric</span> | `closest player` |
 | `proximity-horizontal` | Only calculate horizontal distance for destroyable proximity. | <span className="badge badge--primary">true/false</span> | false |
 
-##### Destroyable Sub-elements
-
-| Element | Description | Value |
-|---|---|---|
-| `<region>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>Region containing the destroyable. | [Bounded Regions](/docs/modules/mechanics/regions) |
-
 ### Examples
 
 ```xml

--- a/docs/modules/objectives/scoring.mdx
+++ b/docs/modules/objectives/scoring.mdx
@@ -69,8 +69,6 @@ A score box will give points to a players team when they enter or bring a redeem
 | Element | Description | Value/Children |
 |---|---|---|
 | `<redeemables>` | Items that can be redeemed at this score box for points. | `<item points="1">` |
-| `<region>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span><span className="badge badge--danger">Required</span>The region where this score box is located. | [Regions](/docs/modules/mechanics/regions) |
-| `<filter>` | <span className="badge badge--secondary" title="Can be either this sub-element or an attribute.">Property</span>Filter who can score in this box. | [Filters](/docs/modules/mechanics/regions) |
 
 ### Examples
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/39b4b207-f72c-4f64-a7fe-4f84f47bb889)
This pull request addresses a common confusion about the table setup throughout the docs. I've merged individual sub-elements that had a property badge, making it listed once under attributes table rather than duplicating them with the same description.

As far I can tell, this was how tables were originally set up at https://docs.oc.tc and no one noticed until recently. Hopefully this makes these pages easier to follow.

**note to reviewers**
* Double check these pages: ~~Spawns (is region an attribute?)~~, ~~Portals~~, ~~Block Drops~~