### PR TITLE
Improve details about PGM docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces **and community servers**, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the [project lead](https://github.com/Electroid). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+## Contributing
+
+We welcome all contributions to documenting PGM and making it approachable for everyone, regardless of their expertise.
+This document serves as a guideline to establish a standard when it comes to submitting changes.
+
+### Scope
+
+PGM Documentation provides detailed and accurate information about features offered by PGM that mapmakers and server administrators can take advantage of.
+
+### Prerequisites
+
+* [Git (advanced users)](https://git-scm.com/downloads), [GitHub Desktop (recommended)](https://desktop.github.com/download/), or [alternative GUI clients](https://git-scm.com/downloads/guis).
+* [NodeJS (LTS version preferred)](https://nodejs.org)
+* Text editors like [Notepad++](https://notepad-plus-plus.org/), [Visual Studio Code](https://code.visualstudio.com/), or [Sublime Text](https://www.sublimetext.com/)
+    * If you are on Windows, avoid using the built-in Notepad program as it lacks several features and can affect files in unexpected ways.
+    * Additionally, Windows users should enable file extensions by clicking `View`, `Show`, and selecting `File name extensions`.
+
+### Steps
+
+1. Clone this repository.
+    ```
+    git clone git@github.com:PGMDev/Website.git
+    ```
+3. Navigate to the repository in the terminal, and then run `npm install`.
+    * You will only need to do this occasionally, especially for package updates.
+2. After installation finishes, run `npm start` to start a local webserver.
+    * You can stop this at any time by pressing `Ctrl` + `C`.
+3. Make your changes, which will appear in your web browser.
+4. Commit your changes, using the `-S` and `-s` tag to [sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and [certify](https://developercertificate.org) the origin of your contributions.
+    ```bash
+    git commit -S -s -m "A short description of your changes"
+    ```
+5. Submit changes in a pull request for review and feedback.
+6. Depending on where you host it, you can build the website using `npm run build` if you intend to upload it yourself or build it _and_ deploy it to GitHub Pages using the [Action workflow](/.github/workflows/deploy.yml).
+    * Some modifications will be needed to deploy outside the pgm.dev environment.
+
+### Pull requests
+
+Before opening a pull request, please:
+
+- Verify that there is no ongoing discussion concerning the implementation you wish to contribute. You can search for such a discussion in the [plugin's repository issues page](https://github.com/PGMDev/PGM/issues).
+- Make sure your contribution follows American (US) English grammar rules and spelling, e.g. "color" and not "colour" or "center" and not "centre."
+- If editing pages in the `mdx` format, try to use [Markdown](https://commonmark.org/help/) and avoid HTML as much as possible.
+- PGMDev enforces the *Developer Certificiate of Origin* (DCO). As such, you must sign off your commits.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,21 @@
-# PGM Documentation Website
+# PGM Documentation Website [![Discord](https://img.shields.io/discord/730855489767997511?color=blue&label=discord&logo=discord)](https://discord.gg/pEEcwTk)
 
 Source for the official [PGM plugin](https://github.com/PGMDev/PGM) documentation, using [Docusaurus](https://docusaurus.io/).
 
 ## Overview
 
-This website aims to be a direct successor to the old [XML Documentation website](https://github.com/OvercastNetwork/docs.oc.tc), and much of its content will be inherited. However, since PGM has now been open-sourced, this new website aims to widen the scope and introduce more materials, ranging from map & XML documentation, to PGM's features, to development processes for contributing features to PGM. As such, this website is designed not only for individual server administrators and map developers, but also for contributors to the PGM project and its community at large.
+This website aims to be a direct successor to the old [XML Documentation website](https://github.com/OvercastNetwork/docs.oc.tc), and much of its content will be inherited. Ever since the original PGM project went open source, the current iteration has seen some increasing disparities. This website aims to widen the scope and introduce more materials, ranging from map and XML documentation to PGM's features, to development processes for contributing features to PGM. As such, this website is designed not only for individual server administrators and map developers but also for contributors to the PGM project and its community at large.
 
 ## Usage
 
-Follow the steps below to get a working local installation of this documentation website.
+See [`CONTRIBUTING`](.github/CONTRIBUTING.md) on how you can get started.
 
-1. Run `npm install` in this project's root folder. This will install all dependencies.
-2. Once it's done, run `npm start`. This command starts a local development server and opens up a browser window. Most changes are reflected live without needing to restart the server.
-3. Depending where you host it, you can build the website using `npm run build` if you intend to upload it yourself or build it _and_ deploy it to GitHub pages using the [Action workflow](.github/workflows/deploy.yml).
-    * Some modifications will be needed to deploy outside the pgm.dev environment.
-
-## How to Contribute
-
-Before opening a Pull Request, please:
-
-- Verify that there is no ongoing discussion concerning the implementation you wish to contribute. You can search for such a discussion in the [plugin's repository issues page](https://github.com/PGMDev/PGM/issues).
-- Make sure your contribution follows American (US) English grammar rules and spelling, e.g. "color" and not "colour".
+Contributors are encouraged to read over the [code of conduct](.github/CODE_OF_CONDUCT.md).
 
 ## Governance
 
-This project is maintained by [CoWinkKeyDinkInc](https://github.com/CoWinkKeyDinkInc), with assistance from [Electroid](https://github.com/Electroid) and other members from the [PGM community](https://discord.gg/RTcBe5AKRA).
+This project is maintained by [CoWinkKeyDinkInc](https://github.com/CoWinkKeyDinkInc), with assistance from [Electroid](https://github.com/Electroid) and other members from the PGM community.
 
 ## License
 
-> [**Apache-2.0**](LICENSE)
+> [**Apache 2.0**](LICENSE)


### PR DESCRIPTION
* Copied code of conduct from the main PGM project, makes GitHub stop complaining about not having one here.
* Moved contributing steps out of readme into its own file, also makes GitHub stop complaining and show it in more places (especially when opening issues and pull requests)
    * I also didn't want to teach anyone how to contribute to this, hence my creating an overkill solution to this.
* Changed readme to resemble PGM's version. Also reworded the overview paragraph to stop sounding like we're still in 2019-20.