### PR TITLE
Fix filter in Filters example

### DIFF
--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -593,7 +593,7 @@ _Examples_
 <!-- Match if there are 1 to 3 players sneaking in region X -->
 <players min="1" max="3">
     <all>
-        <sneaking/>
+        <crouching/>
         <region id="region-x"/>
     </all>
 </players>


### PR DESCRIPTION
Filter example in the Player Count Filter section uses ``<sneaking/>`` (a filter that doesn't exist) instead of the correct ``<crouching/>``.
![image](https://github.com/user-attachments/assets/6e4b7f7e-b60f-40bf-abaf-db49738b9950)
