### PR TITLE
docs: document shop filterability, correct `kit` to `action`

### DIFF
--- a/docs/modules/gear/shops.mdx
+++ b/docs/modules/gear/shops.mdx
@@ -34,23 +34,25 @@ Players can also buy a kit, instead of individual items, or use muiltiple curren
 
 #### Category Attributes
 
-| Element | Description | Value |
-|---|---|---|
+| Element | Description | Value | Default |
+|---|---|---|---|
 | `id` | <span className="badge badge--danger">Required</span>Unique identifier used to reference this category from other places in the XML. | <span className="badge badge--primary">String</span> |
 | `name` | The display name for the category. | <span className="badge badge--primary">Formatted Text</span> |
 | `material` | The item to display as an icon for the category. | [Material Name](/docs/reference/items/inventory#material-matchers) |
+| `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filters whether to show the category in the shop. | [Filter](/docs/modules/mechanics/filters) | `always` |
 
 #### Item Attributes
 
 Items have unique attributes when used in a shop, usually for currency purchases.
 Items can be purchased with multiple currencies using the `<payment>` tag.
 
-| Element | Description | Value |
-|---|---|---|
+| Element | Description | Value | Default |
+|---|---|---|---|
 | `currency` | The currency needed to purchase. | [Material Name](/docs/reference/items/inventory#material-matchers) |
 | `price` | The amount of a currency needed to purchase. | <span className="badge badge--primary">Number</span> |
 | `kit` | The kit to give to players purchasing the item. | [Kit](/docs/modules/gear/kits) |
 | `color` | Set the currency's display text color. This is used for associating colors with different currency tiers. | [Chat Color Name](/docs/reference/misc/formatting#chat-colors) |
+| `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filters whether to show the item in the shop category. | [Filter](/docs/modules/mechanics/filters) | `always` |
 
 ### Examples
 

--- a/docs/modules/gear/shops.mdx
+++ b/docs/modules/gear/shops.mdx
@@ -50,7 +50,7 @@ Items can be purchased with multiple currencies using the `<payment>` tag.
 |---|---|---|---|
 | `currency` | The currency needed to purchase. | [Material Name](/docs/reference/items/inventory#material-matchers) |
 | `price` | The amount of a currency needed to purchase. | <span className="badge badge--primary">Number</span> |
-| `kit` | The kit to give to players purchasing the item. | [Kit](/docs/modules/gear/kits) |
+| `action` | A player-scoped action to execute after the player purchases an item. | [Action](/docs/modules/mechanics/actions-triggers) |
 | `color` | Set the currency's display text color. This is used for associating colors with different currency tiers. | [Chat Color Name](/docs/reference/misc/formatting#chat-colors) |
 | `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filters whether to show the item in the shop category. | [Filter](/docs/modules/mechanics/filters) | `always` |
 


### PR DESCRIPTION
Documents that shop categories and shop items are filterable, allowing map authors to restrict their visibility. Additionally, this PR changes the `kit` attribute to `action` to better reflect the expected data.

Ref: https://github.com/PGMDev/PGM/blob/e50d824efc5ab83ea34afbd79f1dfc646b5a43ab/core/src/main/java/tc/oc/pgm/shops/ShopModule.java#L96 (shop categories)
Ref: https://github.com/PGMDev/PGM/blob/e50d824efc5ab83ea34afbd79f1dfc646b5a43ab/core/src/main/java/tc/oc/pgm/shops/ShopModule.java#L158 (shop items)