### PR TITLE
Enhance docs for inline elements

### DIFF
--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -122,6 +122,12 @@ In the future, some features that are currently used in Kits may be transferred 
 | `index` | If setting an array-type variable, the expression to be evaluated.<br />*Required when using array-type variables.* | <span className="badge badge--primary">Expression</span> |
 | `value` | <span className="badge badge--danger">Required</span>Sets a new value for the variable. | <span className="badge badge--primary">Expression</span> |
 
+**Alternative Inline Syntax:** Variable assignments can be written using the `:=` operator as `variable_name := value` or `variable_name[index] := value` for array variables.
+
+```xml
+<trigger filter="some-condition" action="player_score := player_score + 10" scope="player"/>
+```
+
 ### Kill-Entities Attributes
 
 | Attribute | Description | Value |

--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -68,9 +68,13 @@ and assigned an `id` used to reference them elsewhere.
 
 ### Inline Filters
 
-Inline filters allow you to write an expression that internally creates a filter whenever a filter ID is requested.
-This is useful for scenarios where you may need to create a one-off filter.
+Inline filters allow you to write expressions that create filters dynamically, supporting both function-like syntax and variable expressions.
 
+**Function Syntax:** `all()`, `any()`, `one()`, `not()`, `allow()`, `deny()` can be used with nested filter references.
+
+**Variable Expressions:** Variables can be used directly with comparison operators: `=`, `[min,max]`, `min..`, `[min,oo)`.
+
+_Examples_
 ```xml
 <variables>
     <variable id="some_variable" scope="match"/>
@@ -87,6 +91,9 @@ This is useful for scenarios where you may need to create a one-off filter.
             <message text="The variable is 5 or more!"/>
         </action>
     </trigger>
+    <!-- Function-style inline filters -->
+    <trigger filter="all(team-red, holding-sword)" scope="player"/>
+    <trigger filter="not(team-red)" scope="player"/>
 </actions>
 
 <filters>

--- a/docs/modules/mechanics/variables.mdx
+++ b/docs/modules/mechanics/variables.mdx
@@ -65,6 +65,8 @@ Setting variables are done inside the [Actions & Triggers](/docs/modules/mechani
 The `<set>` action which changes the variables, waits to be called by a trigger after a filter activates it.
 The `value` attribute can do any basic mathematical expressions.
 
+Alternatively, variables can be set using inline syntax with the `:=` operator directly in trigger actions.
+
 _Example_
 
 ```xml
@@ -74,11 +76,16 @@ _Example_
         <set var="flag_captures" value="flag_captures+1">
     </action>
     <trigger filter="flag-cap-filter" action="score-points" scope="player"/>
+    
+    <!-- Alternative inline syntax -->
+    <trigger filter="flag-cap-filter" action="flag_captures := flag_captures + 1" scope="team"/>
 </action>
 
 ...
 <!-- Sets some_variable to 0, 1, 2, 3, or 4 randomly -->
 <set var="some_variable" value="floor(random() * 5)"/>
+<!-- Alternative inline syntax -->
+<trigger filter="some-condition" action="some_variable := floor(random() * 5)" scope="match"/>
 ...
 ```
 


### PR DESCRIPTION

Updated documentation to include missing inline syntax info.

- Added inline variable assignment syntax (`:=` operator)
- Enhanced inline filter documentation with function syntax
- Added variable expressions with comparison operators
