### PR TITLE
Document proto 1.5.1

### DIFF
--- a/docs/modules/general/proto.mdx
+++ b/docs/modules/general/proto.mdx
@@ -20,12 +20,13 @@ Mapmakers should always use the latest supported proto version, and this may be 
 
 | Attribute | Description | Value |
 |---|---|---|
-| `proto` | <span className="badge badge--danger">Required</span>The map XML's protocol version. | <span className="badge badge--success">Recommended</span>`1.5.0` |
+| `proto` | <span className="badge badge--danger">Required</span>The map XML's protocol version. | <span className="badge badge--success">Recommended</span>`1.5.1` |
 
 ##### Map Protocol Values
 
 | Version | Description |
 |---|---|
+| `1.5.1` | Refer to [Changes in 1.5.1](#changes-in-151). |
 | `1.5.0` | Refer to [Changes in 1.5.0](#changes-in-150). |
 | `1.4.2` | Refer to [Changes in 1.4.2](#changes-in-142). |
 | `1.4.1` | No change in features on PGM. Use `1.4.0` or `1.4.2` instead. |
@@ -39,12 +40,18 @@ Mapmakers should always use the latest supported proto version, and this may be 
 
 ## Map Protocol Changelog
 
-### Changes in 1.5.0
+### Changes in 1.5.1
 
-:::note
-`1.5.0` is now available. As the latest protocol version, it is not fully polished, so bugs are expected.
-If you would like to learn more or report issues, please visit the [PGM issue tracker](https://github.com/PGMDev/PGM/issues).
-:::
+#### Breaking
+
+- Some variables and some additional filters are now their own IDs that will be reserved by PGM. Those IDs can be referenced anywhere in the XML.
+  - This applies to the following filters: `gliding` and `riptiding`, and the variable `worldtime`.
+
+#### New
+
+- Inner [flag posts](/docs/modules/objectives/ctf#posts) are now registered. Prior to this proto, only the top-level post could be referenced, while inner posts were treated as dummies.
+
+### Changes in 1.5.0
 
 #### Breaking
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,7 +128,7 @@ const config = {
       announcementBar: {
         id: 'new_features',
         content:
-          'New Features: <a href="/docs/modules/general/proto">Proto 1.5.0</a>, <a href="/docs/modules/mechanics/tracking-compass">Tracking Compass</a>, <a href="/docs/modules/gear/consumables">Consumables</a>, and <a href="/docs/modules/general/main#map-variants">Map Variants</a>',
+          'New Features: <a href="/docs/modules/general/proto">Proto 1.5.1</a>, <a href="/docs/modules/mechanics/tracking-compass">Tracking Compass</a>, <a href="/docs/modules/gear/consumables">Consumables</a>, and <a href="/docs/modules/general/main#map-variants">Map Variants</a>',
         backgroundColor: '#fafbfc',
         textColor: '#091E42',
         isCloseable: true,


### PR DESCRIPTION
- Updated announcement bar to mention proto 1.5.1
- Deleted the info admonition since proto 1.5 has been out for a while without any major issues

This was created in preparation for PGMDev/PGM#1663