### PR TITLE
Fix wrong tag name in fireworks

### DIFF
--- a/docs/modules/gear/items.mdx
+++ b/docs/modules/gear/items.mdx
@@ -273,7 +273,7 @@ You can define custom explosion designs when creating and giving a firework rock
 
 | Sub-element ||
 |---|---|
-| `<firework> </firework>` | Define an explosion effect design. |
+| `<explosion> </explosion>` | Define an explosion effect design. |
 
 ##### Firework Attributes
 


### PR DESCRIPTION
The `explosion` tag was incorrectly named as `firework`