### PR TITLE
Document mob spawners, use proto 1.5.1 everywhere, and more

### DIFF
--- a/docs/examples/airship-battle.mdx
+++ b/docs/examples/airship-battle.mdx
@@ -26,7 +26,7 @@ Make the lava leak by destroying the obsidian blocks containing it and other obs
 Every map XML file starts with the XML header and then the base `<map>` module.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <!-- Specifies what the map is called -->
 <name>Airship Battle</name>
 <!-- Shows the map creation date when a user runs /map in game -->

--- a/docs/examples/harb.mdx
+++ b/docs/examples/harb.mdx
@@ -20,7 +20,7 @@ _The large spawn island for harb, where players initially spawn at when the map 
 Every map XML file starts with the XML header and then the base `<map>` module.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <!-- Specifies what the map is called -->
 <name>Harb</name>
 <!-- Shows the map creation date when a user runs /map in game -->

--- a/docs/examples/ozone.mdx
+++ b/docs/examples/ozone.mdx
@@ -21,7 +21,7 @@ _This map was copied in 1/4th sections._
 Every map XML file starts with the XML header and then the base `<map>` module.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <!-- Specifies what the map is called -->
 <name>Ozone FFA</name>
 <!-- States what version the map is -->

--- a/docs/examples/race-for-victory.mdx
+++ b/docs/examples/race-for-victory.mdx
@@ -31,7 +31,7 @@ to help their way back to base!_
 Every map XML file starts with the XML header and then the base `<map>` module.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <!-- Specifies what the map is called -->
 <name>Race for Victory</name>
 <!-- States what version the map is -->

--- a/docs/examples/the-fenland.mdx
+++ b/docs/examples/the-fenland.mdx
@@ -21,7 +21,7 @@ All players spawn with diamond pickaxes necessary to break them._
 Every map XML file starts with the XML header and then the base `<map>` module.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <!-- Specifies what the map is called -->
 <name>The Fenland</name>
 <!-- Shows the map creation date when a user runs /map in game -->

--- a/docs/examples/warlock.mdx
+++ b/docs/examples/warlock.mdx
@@ -19,7 +19,7 @@ _The monument is obsidian protected by stone bricks and a wooden pressure plate 
 Every map XML file starts with the XML header and then the base `<map>` module.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <!-- Specifies what the map is called -->
 <name>Warlock</name>
 <!-- Shows the map creation date when a user runs /map in game -->

--- a/docs/guides/xml-pointers/conventions.mdx
+++ b/docs/guides/xml-pointers/conventions.mdx
@@ -11,7 +11,7 @@ Modules must all start on column one.
 This means that all children tags under the `<map>` tag must be aligned with said `<map>` tag.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <name>Blocks DTC</name>
 <version>1.3.4</version>
 <objective>Leak lava from the enemy's obsidian core.</objective>
@@ -23,7 +23,7 @@ This means that all children tags under the `<map>` tag must be aligned with sai
 Modules that have sub elements such as the `author` tag must be indented with 4 spaces below the parent element.
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 ...
 <authors>
     <author uuid="060baa18-2852-40d8-afcb-e61607c04be3"/> <!-- PepsiDog -->
@@ -38,7 +38,7 @@ That means the end of one module should have the start of another on the immedia
 
 ```xml
 <!-- Correct -->
-<map proto="1.5.0">
+<map proto="1.5.1">
 <name>Blocks DTC</name>
 <version>1.3.4</version>
 <objective>Leak lava from the enemy's obsidian core.</objective>
@@ -47,7 +47,7 @@ That means the end of one module should have the start of another on the immedia
 
 ```xml
 <!-- Incorrect! -->
-<map proto="1.5.0">
+<map proto="1.5.1">
 
 <name>Blocks DTC</name>
 
@@ -90,7 +90,7 @@ Contributors are optional but are still to remain near the top of a XML file.
 :::
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <name>Blocks DTC</name>
 <version>1.3.4</version>
 <objective>Leak lava from the enemy's obsidian core.</objective>
@@ -109,7 +109,7 @@ All maps should use the latest [protocol version](/docs/modules/general/proto).
 The proto version can be defined with this line:
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 ```
 
 ### Authors and Contributors

--- a/docs/modules/environment/world.mdx
+++ b/docs/modules/environment/world.mdx
@@ -37,7 +37,7 @@ This means that only the terrain that you have modified needs to be saved with t
 | `vanilla` | Specify if this world uses the vanilla or null chunk generator. | <span className="badge badge--primary">true/false</span> | false |
 | `seed` | The world's seed that determines how the world is generated. | <span className="badge badge--primary">String</span> |
 | `environment` | The world's dimension type.<br />**Note:** Worlds with `the end` environment are not supported in Minecraft 1.8. | `normal`<br />`nether`<br />`the end` | `normal` |
-| `pre-match-physics` | <span className="badge badge--danger" title="This feature once existed, but has not been re-implemented in modern versions of PGM.">N/A</span>Allow physics events, such as water flowing, before the match starts. | <span className="badge badge--primary">true/false</span> | false |
+| `pre-match-physics` | Allow physics events, such as water flowing, before the match starts. | <span className="badge badge--primary">true/false</span> | false |
 
 ```xml
 <!-- Make a vanilla world with the seed 'qwerty' -->

--- a/docs/modules/general/main.mdx
+++ b/docs/modules/general/main.mdx
@@ -43,7 +43,7 @@ The map's version should follow the versioning schema `major.minor.patch`.
 | `<gamemode>` | The gamemode(s) of this map. If this is not specified the map will set the gamemode(s) to whatever modules are used. | <span className="badge badge--primary">Gamemode ID</span> |
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <name>Map Name</name>
 <version>1.0.0</version>
 <objective>Short description about the map's objective.</objective>

--- a/docs/modules/general/preprocessing.mdx
+++ b/docs/modules/general/preprocessing.mdx
@@ -70,7 +70,7 @@ Additionally, a variant can also contain constants, which allows you to define t
 ### Example
 
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <name>Map Name</name>
 <variant id="5v5">5v5</variant> <!-- Loaded as "Map Name: 5v5" -->
 <variant id="tournament">TE</variant> <!-- Loaded as "Map Name: TE" -->
@@ -152,7 +152,7 @@ PGM will search and replace any corresponding placeholders (`${constant_id}`) wi
 
 The following example utilizes both map variants and constants.
 ```xml
-<map proto="1.5.0">
+<map proto="1.5.1">
 <name>Map Name</name>
 <variant id="5v5">5v5</variant> <!-- Loaded as "Map Name: 5v5" -->
 <variant id="tournament">TE</variant> <!-- Loaded as "Map Name: TE" -->

--- a/docs/modules/mechanics/damage.mdx
+++ b/docs/modules/mechanics/damage.mdx
@@ -28,14 +28,25 @@ The difficulty level can be set to `peaceful`, `easy`, `normal`, or `hard`. The 
 
 ### Hunger
 
-Specify if a player can starve to death, usually used with the difficulty setting.
+The hunger module allows you to control depletion and replenishment separately.
+For backward compatibility, replenishment will default to the same as depletion.
 This can also be accomplished with the [`naturalRegeneration` gamerule](/docs/modules/mechanics/gamerules).
 
 ```xml
 <hunger>
-    <depletion>off</depletion>
+    <depletion>off</depletion> <!-- Can't lose hunger (e.g. sprinting) -->
+    <replenishment>on</replenishment> <!-- Can gain hunger (e.g. eating) -->
 </hunger>
+
+<hunger depletion="true" replenishment="false"/> <!-- Can lose hunger, but not gain it -->
 ```
+
+:::tip
+If you are updating an older map XML, you can simplify the hunger module from the above to just the following, which will disable depletion but allow replenishment.
+```xml
+<hunger depletion="false"/>
+```
+:::
 
 ### Damage Filtering
 

--- a/docs/modules/mechanics/regions.mdx
+++ b/docs/modules/mechanics/regions.mdx
@@ -106,7 +106,7 @@ The region an apply affects can be specified as an attribute or in a `<region>` 
 |---|---|---|
 | `kit` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Give a kit to players entering the region. | [Kit](/docs/modules/gear/kits) |
 | `lend-kit` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Give a kit to players entering the region, and remove it when they leave the region. This can be used only with removable kits. Any non-removable kit will generate an error. The kits page explains which kit types are removable. | [Kit](/docs/modules/gear/kits) |
-| `velocity` | Change a player's velocity when they enter the region. | <span className="badge badge--primary">X,Y,Z</span> |
+| `velocity` | Change a player's velocity when they enter the region.<br />**Note:** The axis value cannot exceed ±3.9, otherwise it will be clamped. | <span className="badge badge--primary">X,Y,Z</span> |
 | `filter` | <span className="badge badge--secondary" title="Can be either this attribute or a sub-element.">Property</span>Filter when/if kits and velocities are applied. | [Filter](/docs/modules/mechanics/filters) |
 
 _Apply Examples_

--- a/docs/modules/mechanics/spawners.mdx
+++ b/docs/modules/mechanics/spawners.mdx
@@ -2,18 +2,12 @@
 sidebar_position: 10
 id: spawners
 title: Spawners
-description: The spawners module provides an easy way of spawning items and splash potions into the world, without using actual spawner blocks.
 ---
 
-The `<spawners>` module provides an easy way of spawning items and splash potions into the world, without using actual spawner blocks with NBT editors.
+The Spawners module provides an easy way of spawning items, splash potions, and living entities into the world, without using actual spawner blocks with NBT editors.
 
 The module uses the same syntax as [Kits](/docs/modules/gear/kits) to
 define items and makes use of a specific [region](/docs/modules/mechanics/regions) to spawn them in.
-
-:::info
-Currently, only dropped items and splash potions are supported by this module.
-Other types of entities may be supported in the future.
-:::
 
 | Element | Description |
 |---|---|
@@ -41,8 +35,11 @@ Other types of entities may be supported in the future.
 |---|---|---|
 | `<item> </item>` | An item that will be dropped in the `spawn-region`. | [Item](/docs/modules/gear/items) |
 | `<potion> </potion>` | A single splash potion that will be dropped in the `spawn-region`. | [Potion Effects](/docs/modules/gear/potions) |
+| `<mob />` | A living entity that will be spawned in the `spawn-region`.<br />**Note:** Wither and Ender Dragon cannot be spawned. | [Creature Type](/docs/reference/entities/entity-types#creature-types) |
 
-### Examples
+## Examples
+
+### Item Spawner
 
 This will spawn golden swords (in stacks of 1) in the red base, provided there is at least 1 person in that base.
 The swords will spawn in ramdom intervals of 2s - 10s.
@@ -55,6 +52,8 @@ The <label>filter</label> insures that only players on the red team can trigger 
     </spawner>
 </spawners>
 ```
+
+### Splash Potion Spawner
 
 This will spawn a single splash potion that gives players Absorption III, Speed II and Jump Boost II.
 The speed and jump boost effects will both last 10 seconds and aborbtion will last 60 seconds.
@@ -69,6 +68,68 @@ The `damage` attribute will give the potion a red appeareance based on
             <effect>speed</effect>
             <effect>jump_boost</effect>
         </potion>
+    </spawner>
+</spawners>
+```
+
+### Mob Spawner
+
+This will spawn baby zombies named "Boss" with 20 hearts and are on fire for 30 seconds.
+
+```xml
+<spawners>
+    <spawner spawn-region="south-mob-point" player-region="south-mob" delay="4s">
+        <mob type="Zombie" custom-name="Boss" custom-name-visible="true" baby="true"
+             health="40" max-health="40" fire-ticks="600" can-pickup-items="false"/>
+    </spawner>
+</spawners>
+```
+
+This will spawn bees that are silent, glowing, invulnerable, and have AI.
+They will also be permanently angry, have nectar, and be unable to enter hives.
+
+```xml
+<spawners>
+    <spawner spawn-region="north-mob-point" player-region="north-mob" delay="4s">
+        <mob type="Bee" silent="true" glowing="true" invulnerable="true" ai="true"
+             anger="100" has-nectar="true" cannot-enter-hive-ticks="600"/>
+    </spawner>
+</spawners>
+```
+
+You can also spawn multiple mobs with predefined kits, even with minor changes on a per-mob basis.
+This example will spawn a normal skeleton and a wither skeleton with a kit called "boss-skeleton".
+
+```xml
+<kits>
+    <kit id="boss-skeleton">
+        <helmet material="iron helmet" drop-chance="0"/>
+        <chestplate material="iron chestplate" drop-chance="0"/>
+        <item slot="weapon.mainhand" material="iron sword" unbreakable="true" drop-chance="0.7"/>
+        <effect duration="255">strength</effect>
+        <attribute operation="add" amount="10">generic.max_health</attribute>
+    </kit>
+</kits>
+
+<spawners>
+    <!-- This mob will use the "boss-skeleton" kit defined above -->
+    <spawner spawn-region="west-mob-point" player-region="west-mob" delay="4s">
+        <mob type="Skeleton" custom-name="Captain" kit="boss-skeleton"/>
+    </spawner>
+    <!-- This mob will use the "boss-skeleton" kit defined above, but will also have its own kit -->
+    <spawner spawn-region="center-mob-point" player-region="center-mob" delay="4s">
+        <mob type="WitherSkeleton" custom-name="King" kit="boss-skeleton">
+            <kit>
+                <effect amplifier="2">speed</effect>
+                <attribute operation="add" amount="5">generic.attack_damage</attribute>
+            </kit>
+        </mob>
+    </spawner>
+    <!-- This mob will use its own kit -->
+    <spawner spawn-region="east-mob-point" player-region="east-mob" delay="4s">
+        <mob type="Spider" custom-name="Swift">
+            <kit attribute="generic.movement_speed:multiply:1.5;generic.attack_damage:add:3"/>
+        </mob>
     </spawner>
 </spawners>
 ```


### PR DESCRIPTION
* Documented mob spawners & using kits with it, resolves #331 
* Added a note about velocity value clamping, resolves #307 
* Use proto 1.5.1 in every XML examples that explicitly mentions it
* Removed N/A badge from `pre-match-physics` entry, because PGM now has it per PGMDev/PGM#1665
* Documented hunger module updates (PGMDev/PGM#1714)