### PR TITLE
Document all these big beautiful examples

### DIFF
--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -173,18 +173,52 @@ In the future, some features that are currently used in Kits may be transferred 
 
 | Attribute | Description | Value |
 |---|---|---|
+| `slots` | Restricts which inventory slot(s) to modify. | [Slot Groups](/docs/reference/items/inventory/#slot-groups) |
 | `keep-amount` | Player recives the same amount of the new item as they had of the old item. | <span className="badge badge--primary">true/false</span> |
 | `keep-enchants` | Enchantments on the old item will be applied to the new item. | <span className="badge badge--primary">true/false</span> |
 | `ignore-metadata` | Ignore the metadata of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `amount` | Match for item stacks that have a certain amount of items in a range. | <span className="badge badge--primary">Range</span> |
 
+
 ### Enchant-Item Attributes
 
 | Attribute | Description | Value |
 |---|---|--|
+| `slots` | Restricts which inventory slot(s) to modify. | [Slot Groups](/docs/reference/items/inventory/#slot-groups) |
 | `enchantment` | An item enchantment. | [Enchantment Name](/docs/reference/items/enchantments) |
 | `level` | The specified enchantment's level. | <span className="badge badge--primary">Expression</span> |
 | `ignore-metadata` | Ignore the metadata of the item when matching. | <span className="badge badge--primary">true/false</span> |
+
+```xml
+<filters>
+    <carrying id="has-flame-bow" ignore-name="true">
+        <item material="bow" enchantment="flame" unbreakable="true"/>
+    </carrying>
+    <wearing id="wearing-leather-helmet">
+        <item material="leather helmet"/>
+    </wearing>
+</filters>
+<actions>
+    <!-- If a player is carrying a flame bow, replace it with a power bow -->
+     <trigger filter="has-flame-bow" scope="player">
+        <action id="flame" expose="true">
+            <replace-item ignore-name="true">
+                <find material="bow" enchantment="flame" unbreakable="true"/>
+                <replace material="bow" enchantment="power" unbreakable="true"/>
+            </replace-item>
+        </action>
+     </trigger>
+    <!-- When a player wears a leather helmet, enchant it -->
+    <trigger filter="wearing-leather-helmet" scope="player">
+        <action>
+            <!-- Filter for only the helmet worn by the player -->
+            <enchant-item enchantment="protection" level="2" slots="armor.head">
+                <find material="leather helmet"/>
+            </enchant-item>
+        </action>
+    </trigger>
+</actions>
+```
 
 ### Take-Payment
 

--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -179,7 +179,6 @@ In the future, some features that are currently used in Kits may be transferred 
 | `ignore-metadata` | Ignore the metadata of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `amount` | Match for item stacks that have a certain amount of items in a range. | <span className="badge badge--primary">Range</span> |
 
-
 ### Enchant-Item Attributes
 
 | Attribute | Description | Value |
@@ -386,6 +385,7 @@ Selects the first matching value from a list of candidate case branches.
     <case match="20" filter="red-team" result="`aHealthy `9red`a player"/>
 </switch>
 ```
+
 #### Attributes
 | Attribute | Description | Type |
 |---|---|---|
@@ -417,7 +417,6 @@ Refers to a replacement in the global registry. Takes in an `id` attribute, whic
     </replacements>
 </message>
 ```
-
 
 ## Examples
 

--- a/docs/modules/mechanics/actions-triggers.mdx
+++ b/docs/modules/mechanics/actions-triggers.mdx
@@ -25,8 +25,10 @@ In the future, some features that are currently used in Kits may be transferred 
 | `<schedule> </schedule>` | Adds a delay between actions. |
 | `<kill-entities/>` | Removes entities based on a filter. |
 | `<kit/>` | Applies a [Kit](/docs/modules/gear/kits). |
-| `<fill/>` | Places blocks in a block-bounded region. |
+| `<fill> </fill>` | Places blocks in a block-bounded region. |
 | `<paste-structure/>` | Places a structure at a specified location when triggered. |
+| `<pickup-flag/>` | Force a player to pick up the specified flag. |
+| `<drop-flag/>` | Force a player to drop the specified flag. |
 | `<open-shop/>` | Open a [shop](/docs/modules/gear/shops) menu when triggered. |
 | `<replace-item> </replace-item>` | Finds and replaces certain items. |
 | `<enchant-item> </enchant-item>` | Enchants the targeted item. |
@@ -134,7 +136,15 @@ In the future, some features that are currently used in Kits may be transferred 
 |---|---|---|
 | `filter` | Filters which entities to remove. | [Filter](/docs/modules/mechanics/filters) |
 
-### Fill Attributes
+### Fill
+
+#### Sub-elements
+
+| Sub-elements | Description |
+|---|---|
+| `<resize/>` | Resize an existing region by the specified values. |
+
+#### Attributes
 
 | Attribute | Description | Value | Default |
 |---|---|---|---|
@@ -143,6 +153,21 @@ In the future, some features that are currently used in Kits may be transferred 
 | `filter` | Filters which blocks get affected. *May impact performance for large fills.* | [Filter](/docs/modules/mechanics/filters) |
 | `events` | Calls events for block placements and removals, which will make it affected by other filters and PGM features. *May impact performance for large fills.* | <span className="badge badge--primary">true/false</span> | false |
 | `update` | Placed blocks will update upon interaction, e.g., redstone, and invalid block placements such as floating ladders, "popping" off. *May impact performance for large fills.* | <span className="badge badge--primary">true/false</span> | true |
+| `min` | How much to expand in the -x, -y and -z directions.<br />*This attribute is only available for resize.* | <span className="badge badge--primary">X,Y,Z</span> ||
+| `max` | How much to expand in the +x, +y and +z directions.<br />*This attribute is only available for resize.* | <span className="badge badge--primary">X,Y,Z</span> ||
+| `relative` | If the min and max should be relative to the original size of the region (proportion) or absolute (number of blocks).<br />*This attribute is only available for resize.* | <span className="badge badge--primary">true/false</span> | false |
+
+```xml
+<action id="fill-regions" expose="true" scope="match">
+    <fill material="glass">
+        <resize min="5,6,5" max="5,4,5" region="monument-region"/>
+    </fill>
+    <fill material="stained_glass:1">
+        <resize min="1,1,1" max="1,1,1" relative="true" region="monument-region"/>
+    </fill>
+    <fill material="obsidian" region="monument-region"/>
+</action>
+```
 
 ### Paste-Structure Attributes
 
@@ -153,6 +178,22 @@ In the future, some features that are currently used in Kits may be transferred 
 | `z` | The Z coordinate of the location to paste the structure, measured in north-south. | <span className="badge badge--primary">Expression</span> |
 | `structure` | The structure to paste. | [Structure ID](/docs/modules/blocks/structures) |
 | `update` | Placed blocks will update upon interaction, e.g., redstone, and invalid block placements such as floating ladders, "popping" off. *May impact performance for large fills.* | <span className="badge badge--primary">true/false</span> | true |
+
+### Pickup-Flag/Drop-Flag Attributes
+
+| Attribute | Description | Value |
+|---|---|---|
+| `flag` | The name of the flag to act upon. | [Flag ID](/docs/modules/objectives/ctf#flags) |
+
+```xml
+<action id="pickup-red-flag" scope="player" expose="true">
+    <pickup-flag flag="red-flag"/>
+</action>
+
+<action id="drop-red-flag" scope="match" expose="true">
+    <drop-flag flag="red-flag"/>
+</action>
+```
 
 ### Open-Shop Attributes
 
@@ -199,20 +240,34 @@ In the future, some features that are currently used in Kits may be transferred 
 </filters>
 <actions>
     <!-- If a player is carrying a flame bow, replace it with a power bow -->
-     <trigger filter="has-flame-bow" scope="player">
+    <trigger filter="has-flame-bow" scope="player">
         <action id="flame" expose="true">
             <replace-item ignore-name="true">
                 <find material="bow" enchantment="flame" unbreakable="true"/>
                 <replace material="bow" enchantment="power" unbreakable="true"/>
             </replace-item>
         </action>
-     </trigger>
+    </trigger>
     <!-- When a player wears a leather helmet, enchant it -->
     <trigger filter="wearing-leather-helmet" scope="player">
         <action>
             <!-- Filter for only the helmet worn by the player -->
             <enchant-item enchantment="protection" level="2" slots="armor.head">
                 <find material="leather helmet"/>
+            </enchant-item>
+        </action>
+    </trigger>
+    <trigger scope="player">
+        <!-- Matches if a player has a vanilla diamond sword in any slot in their inventory -->
+        <filter>
+            <carrying>
+                <item material="diamond sword"/> <!-- Add item attributes as needed -->
+            </carrying>
+        </filter>
+        <action>
+            <!-- Enchants all vanilla diamond swords in the player's inventory with sharpness 2 -->
+            <enchant-item enchantment="sharpness" level="2">
+                <find material="diamond sword"/>
             </enchant-item>
         </action>
     </trigger>

--- a/docs/modules/mechanics/damage.mdx
+++ b/docs/modules/mechanics/damage.mdx
@@ -47,6 +47,7 @@ Regions can also be used since they are filters that filter for a location.
 _Examples_
 
 ```xml
+<!-- Deny taking damage from explosion -->
 <damage>
     <deny>
         <cause>explosion</cause>
@@ -73,6 +74,17 @@ _Examples_
             <class>eagle</class>
             <cause>fall</cause>
         </all>
+    </deny>
+</damage>
+```
+
+```xml
+<!-- Deny taking damage from shot arrows -->
+<damage>
+    <deny>
+        <damager>
+            <entity>arrow</entity>
+        </damager>
     </deny>
 </damage>
 ```
@@ -120,7 +132,8 @@ _Example_
 
 #### Block Explosion Attributes
 
-The `BLOCK_EXPLOSION` damage cause has several extended attributes to customize who/what gets damaged. Only attributes with `false` as the value need to be explicitly defined since all attributes default to `true`.
+The `BLOCK_EXPLOSION` damage cause has several extended attributes to customize who/what gets damaged.
+Only attributes with `false` as the value need to be explicitly defined since all attributes default to `true`.
 
 | Attribute | Description | Value | Default |
 |---|---|---|---|

--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -62,7 +62,7 @@ and assigned an `id` used to reference them elsewhere.
 
     <team id="viridescent-team-filter">viridescent-team</team>
 
-    <!-- More filters-->
+    <!-- More filters -->
 </filters>
 ```
 
@@ -162,6 +162,7 @@ These type of filters apply to anything with a physical location.
 | `<spawn>spawn reason</spawn>` | Matches spawn event reasons, see [Mob Spawning](/docs/modules/environment/mobs). |
 | `<mob>mob name</mob>` | Matches mobs by their name, see [Mob Spawning](/docs/modules/environment/mobs). |
 | `<entity>entity name</entity>` | Match entities such as projectiles, boats, dropped items, etc. |
+| `<damager><entity>...</entity></damager>` | Match the entity that caused the damage, especially projectiles. |
 
 ### Competitor Filters
 
@@ -229,20 +230,20 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
 ```xml
 <filters>
     <wearing id="wearing-protection-chestplate" slots="armor.chest">
-      <item enchantment="protection:1">
-        <match>
-          <all-items/>
-        </match>
-      </item>
+        <item enchantment="protection:1">
+            <match>
+                <all-items/>
+            </match>
+        </item>
     </wearing>
 
     <holding id="holding-block">
-      <item amount="5" name="Block!">
-        <match>
-          <material>stone</material>
-          <material>dirt</material>
-        </match>
-      </item>
+        <item amount="5" name="Block!">
+            <match>
+                <material>stone</material>
+                <material>dirt</material>
+            </match>
+        </item>
     </holding>
 </filters>
 ```
@@ -967,7 +968,7 @@ It returns `ALLOW` as long as the structural load is greater than or equal to th
 This filter is very computationally expensive to apply.
 XML authors should ensure that it is only run when absolutely necessary, e.g. by placing other filters above it.
 They should also not apply it to events that modify large amounts of blocks, such as explosions. 
-This filter requires the falling blocks module to be loaded otherwise it will default to abstain.
+This filter requires the falling blocks module to be loaded, otherwise it will default to abstain.
 :::
 
 _Example_

--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -206,6 +206,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
 |---|---|---|
 | `slots` | Restricts which inventory slot(s) to match for. | [Slot Groups](/docs/reference/items/inventory/#slot-groups) |
 | `amount` | Match for item stacks that have a certain amount of items in a range. | <span className="badge badge--primary">Range</span> |
+| `total-amount` | Match for a player's entire inventory having a certain amount of items in a range. | <span className="badge badge--primary">Range</span> |
 | `ignore-durability` | Ignore the durability of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `ignore-metadata` | Ignore the metadata of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `ignore-name` | Ignore the name of the item when matching. | <span className="badge badge--primary">true/false</span> |

--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -204,11 +204,45 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
 
 | Element | Description ||
 |---|---|---|
+| `slots` | Restricts which inventory slot(s) to match for. | [Slot Groups](/docs/reference/items/inventory/#slot-groups) |
 | `amount` | Match for item stacks that have a certain amount of items in a range. | <span className="badge badge--primary">Range</span> |
 | `ignore-durability` | Ignore the durability of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `ignore-metadata` | Ignore the metadata of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `ignore-name` | Ignore the name of the item when matching. | <span className="badge badge--primary">true/false</span> |
 | `ignore-enchantments` | Ignore the enchantments of the item when matching. | <span className="badge badge--primary">true/false</span> |
+
+#### Item Sub-Element
+
+| Sub-element | Description | Value/Children |
+|---|---|---|
+| `<match> </match>` |<span className="badge badge--warning" title="Only one of this child permitted per parent">Unique</span>Used to define material(s) sharing properties defined in `item`. | <span className="badge badge--secondary">Match Sub-Element</span> |
+
+#### Match Sub-Elements
+| Element | Description | Value/Children |
+|---|---|---|
+| `<material> </material>` | An individual material to match. | [Single Material Pattern](/docs/reference/items/inventory#material-matchers) |
+| `<all-items/>` | Match all materials. |
+| `<all-blocks/>` | Match all block type materials. |
+```xml
+<filters>
+    <wearing id="wearing-protection-chestplate" slots="armor.chest">
+      <item enchantment="protection:1">
+        <match>
+          <all-items/>
+        </match>
+      </item>
+    </wearing>
+
+    <holding id="holding-block">
+      <item amount="5" name="Block!">
+        <match>
+          <material>stone</material>
+          <material>dirt</material>
+        </match>
+      </item>
+    </holding>
+</filters>
+```
 
 ### Event Filters
 

--- a/docs/modules/mechanics/filters.mdx
+++ b/docs/modules/mechanics/filters.mdx
@@ -75,6 +75,7 @@ Inline filters allow you to write expressions that create filters dynamically, s
 **Variable Expressions:** Variables can be used directly with comparison operators: `=`, `[min,max]`, `min..`, `[min,oo)`.
 
 _Examples_
+
 ```xml
 <variables>
     <variable id="some_variable" scope="match"/>
@@ -216,7 +217,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
 
 | Sub-element | Description | Value/Children |
 |---|---|---|
-| `<match> </match>` |<span className="badge badge--warning" title="Only one of this child permitted per parent">Unique</span>Used to define material(s) sharing properties defined in `item`. | <span className="badge badge--secondary">Match Sub-Element</span> |
+| `<match> </match>` | <span className="badge badge--warning" title="Only one of this child permitted per parent">Unique</span>Used to define material(s) sharing properties defined in `item`. | <span className="badge badge--secondary">Match Sub-Element</span> |
 
 #### Match Sub-Elements
 | Element | Description | Value/Children |
@@ -224,6 +225,7 @@ These are the attributes for `<carrying>`, `<holding>`, and `<wearing>`.
 | `<material> </material>` | An individual material to match. | [Single Material Pattern](/docs/reference/items/inventory#material-matchers) |
 | `<all-items/>` | Match all materials. |
 | `<all-blocks/>` | Match all block type materials. |
+
 ```xml
 <filters>
     <wearing id="wearing-protection-chestplate" slots="armor.chest">
@@ -529,7 +531,7 @@ It never matches when the child filter doesn't match. This filter is a [Dynamic 
 | `filter` | <span className="badge badge--danger">Required</span>Filter when the countdown should be active. | [Dynamic Filter](#dynamic-filters) |
 | `message` | Optional timer message to display while counting down. Only players who match the filter can see the timer. If the message contains a placeholder `{0}`, it will be replaced with the remaining time. | <span className="badge badge--primary">String</span> |
 
-```
+```xml
 <!-- Countdown 30s from the moment any player picks up the flag -->
 <!-- (you could then use the countdown filter to kill them, teleport them, etc) -->
 <countdown duration="30s" message="You have {0} to capture the flag!">
@@ -548,7 +550,7 @@ This filter is a [Dynamic Filter](#dynamic-filters).
 | `filter` | <span className="badge badge--danger">Required</span>Filter when the after filter should be active. | [Dynamic Filter](#dynamic-filters) |
 | `message` | Optional message to display after the child filter allows. Only players who match the filter can see the message. If the message contains a placeholder `{0}`, it will be replaced with the remaining time. | <span className="badge badge--primary">String</span> |
 
-```
+```xml
 <!-- Allows 15 seconds after the player gets 1st place -->
 <after duration="15s" message="1st place bonus will apply in {0}"> <!-- Automatically updates to show time -->
     <rank>1</rank>
@@ -569,7 +571,7 @@ This filter is a [Dynamic Filter](#dynamic-filters).
 | `duration` | <span className="badge badge--danger">Required</span>Length of time a pulse remains on in a cycle.<br />*Must be a positive number that is shorter than the period length.* | [Time Period](/docs/reference/misc/time-periods) |
 | `filter` | <span className="badge badge--danger">Required</span>Filter when the pulse should be active; if the filter allows, pulse will be ticking. It can be defined as a unique child element or as an attribute. | [Dynamic Filter](#dynamic-filters) |
 
-```
+```xml
 <filters>
     <!-- Pulses activation for 15 seconds in a 60 second time period -->
     <!-- ie. on for 15 seconds, off for 45 seconds -->
@@ -594,7 +596,7 @@ Coordinates relative to the player are defined using `~` and behave the same lik
 Directions relative to the player use `^`. This can be utilized as a [Dynamic Filter](#dynamic-filters) as long it is used
 with an absolute position.
 
-```
+```xml
 <filters>
     <!-- checks for bedrock placed at this exact coordinate vector (dynamic) -->
     <offset id="hardFilter" vector="10.5,5,15.5">
@@ -991,7 +993,7 @@ Users should use the more specific `<match-started/>`, `<match-running/>` or `<m
 filters instead of `<match-phase>`.
 :::
 
-```
+```xml
 <!-- Filter if the match has started (running or finished) -->
 <match-started/>
 <!-- Filter if the match is currently running -->

--- a/docs/modules/mechanics/spawners.mdx
+++ b/docs/modules/mechanics/spawners.mdx
@@ -28,12 +28,12 @@ Other types of entities may be supported in the future.
 | Attribute | Description | Value | Default |
 |---|---|---|---|
 | `spawn-region` | <span className="badge badge--danger">Required</span>The region in which to spawn the target entities. | [Region](/docs/modules/mechanics/regions) |
-| `player-region` | <span className="badge badge--danger">Required</span>The region used to determine whether the spawner is actively spawning entities. At least 1 player must be in this region for the spawner to be active. | [Region](/docs/modules/mechanics/regions) |
+| `player-region` | The region used to determine whether the spawner is actively spawning entities. At least 1 player must be in this region for the spawner to be active. | [Region](/docs/modules/mechanics/regions) | `everywhere` |
 | `max-entities` | A limit of how many entities this spawner can have spawned at once. | <span className="badge badge--primary">Number</span> | `oo` (infinity) |
 | `delay` | Interval in between spawning attempts. | [Time Period](/docs/reference/misc/time-periods) | 10s |
 | `min-delay` | Used to randomize the spawn interval. Combine this with `max-delay` to create random intervals in between two values.<br />*Cannot be combined with `delay`.* | [Time Period](/docs/reference/misc/time-periods) | `delay` |
 | `max-delay` | Used to randomize the spawn interval. Combine this with `min-delay` to create random intervals in between two values.<br />*Cannot be combined with `delay`.* | [Time Period](/docs/reference/misc/time-periods) | `delay` |
-| `filter` | Filter to further control spawn conditions, will return true if at least one player in `player-region` meets criteria. | [Filter](/docs/modules/mechanics/filters) |
+| `filter` | Filter to further control spawn conditions, will return true if at least one player in `player-region` meets criteria. | [Filter](/docs/modules/mechanics/filters) | `always` |
 
 #### Spawner Sub-elements
 

--- a/docs/modules/mechanics/variables.mdx
+++ b/docs/modules/mechanics/variables.mdx
@@ -25,6 +25,11 @@ You can define as many variables as you want and all variables must have a scope
 | `<with-team/>` | A team-rescoping variable that allows using a specific team's value from a different team-scoped variable as a match-scoped variable. |
 | `<player-location/>` | A variable that reads a player's location components. |
 | `<worldtime/>` | A variable that allows direct access to the world's time. |
+| `<cuboid/>` | A variable that represents a dynamic cuboid region. |
+| `<cylinder/>` | A variable that represents a dynamic cylinder region. |
+| `<block/>` | A variable that represents a dynamic block region. |
+| `<sphere/>` | A variable that represents a dynamic sphere region. |
+| `<point/>` | A variable that represents a dynamic point region. |
 
 ### Variable Attributes
 
@@ -56,6 +61,28 @@ You can define as many variables as you want and all variables must have a scope
 |---|---|---|
 | `id` | Unique identifier used to reference this player-location variable from other places in the XML. | <span className="badge badge--primary">String</span> |
 | `component` | The player's location component to target.<br />`X`, `Y`, `Z`, `YAW`, and `PITCH` represents the player's position and angle.<br />`DIR_X`, `DIR_Y`, and `DIR_Z` represents the player's direction.<br />`VEL_X`, `VEL_Y`, and `VEL_Z` represents the player's velocity.<br />`TARGET_X`, `TARGET_Y`, and `TARGET_Z` represents the block a player is looking at.<br />`PLACE_X`, `PLACE_Y`, and `PLACE_Z` represents the location of a player-placed block.  | <span className="badge badge--secondary">XYZ</span>, <span className="badge badge--secondary">Yaw</span>, <span className="badge badge--secondary">Pitch</span>,<br /><span className="badge badge--secondary">Direction</span>, <span className="badge badge--secondary">Velocity</span>,<br /><span className="badge badge--secondary">Target</span>, <span className="badge badge--secondary">Place</span> |
+
+### Region Variable Attributes
+
+Region variables are used when a region's bounds need to change during a match. Region variables are defined following the same structure seen in [Regions](/docs/modules/mechanics/regions). Region variables are always match scoped, but they can support player variable values.
+
+| Attribute | Description | Value |
+|---|---|---|
+| `id` | Unique identifier used to reference this cuboid variable from other places in the XML. | <span className="badge badge--primary">String</span> |
+
+#### Region Variable Indices
+
+Every region variable behaves like an array where each index corresponds to a specific coordinate or dimension, in the order its attributes are defined in the XML.
+
+| Variable Type | i=0 | i=1 | i=2 | i=3 | i=4 | i=5 |
+|---|---|---|---|---|---|---|
+| `<cuboid min="X1,Y1,Z1" max="X2,Y2,Z2"/>` | X1 | Y1 | Z1 | X2 | Y2 | Z2 |
+| `<cylinder base="X,Y,Z" radius="R" height="H"/>` | X | Y | Z | R | H |
+| `<block>X,Y,Z</block>` | X | Y | Z |
+| `<sphere origin="X,Y,Z" radius="R"/>` | X | Y | Z | R |
+| `<point>X,Y,Z</point>` | X | Y | Z |
+
+**Note:** The `<cuboid/>` variable also supports `size` as an alternative to defining both `min` and `max`.
 
 ## Examples
 
@@ -239,6 +266,32 @@ If a player in blue team triggers `some-filter`, red is reset to 10, and blue wi
             <set var="team_score" value="team_score+5"/>
         <action>
     </trigger>
+</actions>
+```
+
+### Region Variables
+A player uses a consumable and sets a cylinder region around themself, giving speed to whoever is currently inside.
+
+```xml
+<variables>
+    <!-- Cylinder variable set to arbitrary coordinates outside of the map -->
+    <cylinder id="cyl_zone" base="-200,-200,-200" radius="4" height="4"/>
+</variables>
+<actions>
+    <action id="consumable-action" scope="player">
+        <set var="cyl_zone" index="0" value="player.x"/>
+        <set var="cyl_zone" index="1" value="player.y"/>
+        <set var="cyl_zone" index="2" value="player.z"/>
+        <!-- Switch to match scope first, then back to player to iterate over ALL players in the match -->
+        <switch-scope inner="match">
+            <switch-scope inner="player">
+                <!-- Filter for anyone currently inside the cylinder var's new location -->
+                <action filter="cyl_zone">
+                    <kit id="speed-kit"/>
+                </action>
+            </switch-scope>
+        </switch-scope>
+    </action>
 </actions>
 ```
 

--- a/docs/reference/items/inventory.mdx
+++ b/docs/reference/items/inventory.mdx
@@ -21,8 +21,10 @@ import Materials from "../../../src/components/materials";
 
 ### Slot Groups
 
-The <label>slots</label> attribute is used to define a set of slots in a player's inventory that a feature will work in. It can be used with `carrying`, `holding`, and `wearing` filters, as well as the `enchant-item` and `replace-item` actions. Specific slots within a group can be targeted using `group.index`, where the index is relative to that group starting at `0`.
-<br />**Note:** Not to be confused with `slot` used in kits.
+The `slots` attribute is used to define a set of slots in a player's inventory that a feature will work in.
+It can be used with `carrying`, `holding`, and `wearing` filters, as well as the `enchant-item` and `replace-item` actions.
+Specific slots within a group can be targeted using `group.index`, where the index is relative to that group starting at `0`.
+This should not be confused with the kit `slot` attribute.
 
 | Slot Group | Slot Number(s) |
 |---|---|
@@ -34,7 +36,7 @@ The <label>slots</label> attribute is used to define a set of slots in a player'
 | `hands` | Includes `hand`/`mainhand` and `offhand`. |
 | `armor` | Individual armor slots: `armor.head`, `armor.chest`, `armor.legs`, and `armor.feet`. |
 | `equipment` | Includes `armor` and `offhand`.<br />**Note:** Does not include `hand`/`mainhand`. |
-| `cursor` | Item currently held in a player's cursor slot.<br />**Note:** While having your inventory open, if you click once on an item it will then be in your cursor slot. |
+| `cursor` | Item currently held in a player's cursor slot.<br />**Note:** While having your inventory open, clicking once on an item will make it be in your cursor slot. |
 | `crafting` | Includes slots inside a 2x2 or 3x3 crafting grid. |
 | `carrying` | Includes `storage`, `offhand`, `cursor`, and `crafting`. |
 | `all` | Includes `storage`, `offhand`, `armor`, `cursor`, and `crafting`. |

--- a/docs/reference/items/inventory.mdx
+++ b/docs/reference/items/inventory.mdx
@@ -18,6 +18,28 @@ import Materials from "../../../src/components/materials";
   </div>
 </div>
 
+
+### Slot Groups
+
+The <label>slots</label> attribute is used to define a set of slots in a player's inventory that a feature will work in. It can be used with `carrying`, `holding`, and `wearing` filters, as well as the `enchant-item` and `replace-item` actions. Specific slots within a group can be targeted using `group.index`, where the index is relative to that group starting at `0`.
+<br />**Note:** Not to be confused with `slot` used in kits.
+
+| Slot Group | Slot Number(s) |
+|---|---|
+| `hotbar` | Slots `0`-`8`. |
+| `pockets` | Slots `9`-`35`. |
+| `storage` | Includes `hotbar` and `pockets`. |
+| `hand`/`mainhand` | Selected slot on the player's hotbar.<br />**Note:** Incompatible when used together with `hotbar`. |
+| `offhand` | Off-hand slot. |
+| `hands` | Includes `hand`/`mainhand` and `offhand`. |
+| `armor` | Individual armor slots: `armor.head`, `armor.chest`, `armor.legs`, and `armor.feet`. |
+| `equipment` | Includes `armor` and `offhand`.<br />**Note:** Does not include `hand`/`mainhand`. |
+| `cursor` | Item currently held in a player's cursor slot.<br />**Note:** While having your inventory open, if you click once on an item it will then be in your cursor slot. |
+| `crafting` | Includes slots inside a 2x2 or 3x3 crafting grid. |
+| `carrying` | Includes `storage`, `offhand`, `cursor`, and `crafting`. |
+| `all` | Includes `storage`, `offhand`, `armor`, `cursor`, and `crafting`. |
+
+
 ### Material Matchers
 
 Depending on the material/item element used a material or multiple materials can be specified with or without data values.


### PR DESCRIPTION
This pull request adds examples to modules and features that were already documented but lacked enough useful information for mapmakers to start using them immediately. It also adds missing pieces that slipped through prior reviews.

## Big Beautiful Bulletin
- Added enchant-item examples (#157, PGMDev/PGM#1420)
- Documented pickup-flag and drop-flag (PGMDev/PGM#1533)
- Documented damager filter (PGMDev/PGM#1551; this was incorrectly marked as done in a previous issue)
- Documented fill resize sub-element (PGMDev/PGM#1421, resolves #163)
- Documented slot groups with examples (PGMDev/PGM#1634)
- Updated spawners' attribute tables (PGMDev/PGM#1702)

## To-do
- [ ] Examples for these filters: `<attacker> <victim> <same-team> <player> <walking> <sprinting> <grounded> <can-fly> <gliding> <riptiding>`
- [ ] Examples for these actions: `<kill-entities> <open-shop> <replace-item> <enchant-item> <fill> <team-alias> <take-payment> <velocity> <teleport> <paste-structure> <weather>`
- [ ] Examples for these variables: `<array> <player-location>`